### PR TITLE
Remove the `rights` type.

### DIFF
--- a/standard/wasi-filesystem/witx/file_io.witx
+++ b/standard/wasi-filesystem/witx/file_io.witx
@@ -25,6 +25,9 @@
   )
 
   ;;; Force the allocation of space in a file.
+  ;;;
+  ;;; This requires a file descriptor with `access_mode::write` set.
+  ;;;
   ;;; Note: This is similar to `posix_fallocate` in POSIX.
   (@interface func (export "allocate")
     (param $fd $fd)
@@ -59,16 +62,6 @@
     (result $error (expected (error $errno)))
   )
 
-  ;;; Adjust the rights associated with a file descriptor.
-  ;;; This can only be used to remove rights, and returns `errno::notcapable` if called in a way that would attempt to add rights
-  (@interface func (export "fdstat_set_rights")
-    (param $fd $fd)
-    ;;; The desired rights of the file descriptor.
-    (param $fs_rights_base $rights)
-    (param $fs_rights_inheriting $rights)
-    (result $error (expected (error $errno)))
-  )
-
   ;;; Return the attributes of an open file.
   (@interface func (export "filestat_get")
     (param $fd $fd)
@@ -77,6 +70,9 @@
   )
 
   ;;; Adjust the size of an open file. If this increases the file's size, the extra bytes are filled with zeros.
+  ;;;
+  ;;; This requires a file descriptor with `access_mode::write` set.
+  ;;;
   ;;; Note: This is similar to `ftruncate` in POSIX.
   (@interface func (export "filestat_set_size")
     (param $fd $fd)
@@ -86,6 +82,9 @@
   )
 
   ;;; Adjust the timestamps of an open file or directory.
+  ;;;
+  ;;; This requires a file descriptor with `access_mode::write` set.
+  ;;;
   ;;; Note: This is similar to `futimens` in POSIX.
   (@interface func (export "filestat_set_times")
     (param $fd $fd)
@@ -118,6 +117,9 @@
   )
 
   ;;; Read from a file descriptor, without using and updating the file descriptor's offset.
+  ;;;
+  ;;; This requires a file descriptor with `access_mode::read` set.
+  ;;;
   ;;; Note: This is similar to `preadv` in Linux (and other Unix-es).
   (@interface func (export "pread")
     (param $fd $fd)
@@ -130,6 +132,9 @@
   )
 
   ;;; Write to a file descriptor, without using and updating the file descriptor's offset.
+  ;;;
+  ;;; This requires a file descriptor with `access_mode::write` set.
+  ;;;
   ;;; Note: This is similar to `pwritev` in Linux (and other Unix-es).
   ;;;
   ;;; Like Linux (and other Unix-es), any calls of `pwrite` (and other
@@ -146,6 +151,9 @@
   )
 
   ;;; Read from a file descriptor.
+  ;;;
+  ;;; This requires a file descriptor with `access_mode::read` set.
+  ;;;
   ;;; Note: This is similar to `readv` in POSIX.
   (@interface func (export "read")
     (param $fd $fd)
@@ -221,6 +229,9 @@
   )
 
   ;;; Write to a file descriptor.
+  ;;;
+  ;;; This requires a file descriptor with `access_mode::write` set.
+  ;;;
   ;;; Note: This is similar to `writev` in POSIX.
   ;;;
   ;;; Like POSIX, any calls of `write` (and other functions to read or write)

--- a/standard/wasi-filesystem/witx/path.witx
+++ b/standard/wasi-filesystem/witx/path.witx
@@ -105,16 +105,8 @@
     (param $path string)
     ;;; The method by which to open the file.
     (param $oflags $oflags)
-    ;;; The initial rights of the newly created file descriptor. The
-    ;;; implementation is allowed to return a file descriptor with fewer rights
-    ;;; than specified, if and only if those rights do not apply to the type of
-    ;;; file being opened.
-    ;;
-    ;;; The *base* rights are rights that will apply to operations using the file
-    ;;; descriptor itself, while the *inheriting* rights are rights that apply to
-    ;;; file descriptors derived from it.
-    (param $fs_rights_base $rights)
-    (param $fs_rights_inheriting $rights)
+    ;;; The access mode (read, write, or both) for which to open the file.
+    (param $fs_access_mode $access_mode)
     (param $fdflags $fdflags)
     ;;; If a file is created, the filesystem permissions to associate with it.
     (param $permissions $permissions)

--- a/standard/wasi-filesystem/witx/typenames.witx
+++ b/standard/wasi-filesystem/witx/typenames.witx
@@ -193,91 +193,18 @@
   )
 )
 
-;;; File descriptor rights, determining which actions may be performed.
-(typename $rights
-  (flags (@witx repr u64)
-    ;;; The right to invoke `fd_datasync`.
-    ;;
-    ;;; If `path_open` is set, includes the right to invoke
-    ;;; `path_open` with `fdflags::dsync`.
-    $fd_datasync
-    ;;; The right to invoke `fd_read` and `sock_recv`.
-    ;;
-    ;;; If `rights::fd_seek` is set, includes the right to invoke `fd_pread`.
-    $fd_read
-    ;;; The right to invoke `fd_seek`. This flag implies `rights::fd_tell`.
-    $fd_seek
-    ;;; The right to invoke `fd_fdstat_set_flags`.
-    $fd_fdstat_set_flags
-    ;;; The right to invoke `fd_sync`.
-    ;;
-    ;;; If `path_open` is set, includes the right to invoke
-    ;;; `path_open` with `fdflags::rsync` and `fdflags::dsync`.
-    $fd_sync
-    ;;; The right to invoke `fd_seek` in such a way that the file offset
-    ;;; remains unaltered (i.e., `whence::cur` with offset zero), or to
-    ;;; invoke `fd_tell`.
-    $fd_tell
-    ;;; The right to invoke `fd_write` and `sock_send`.
-    ;;; If `rights::fd_seek` is set, includes the right to invoke `fd_pwrite`.
-    $fd_write
-    ;;; The right to invoke `fd_advise`.
-    $fd_advise
-    ;;; The right to invoke `fd_allocate`.
-    $fd_allocate
-    ;;; The right to invoke `path_create_directory`.
-    $path_create_directory
-    ;;; If `path_open` is set, the right to invoke `path_open` with `oflags::create`.
-    $path_create_file
-    ;;; The right to invoke `path_link` with the file descriptor as the
-    ;;; source directory.
-    $path_link_source
-    ;;; The right to invoke `path_link` with the file descriptor as the
-    ;;; target directory.
-    $path_link_target
-    ;;; The right to invoke `path_open`.
-    $path_open
-    ;;; The right to invoke `fd_readdir`.
-    $fd_readdir
-    ;;; The right to invoke `path_readlink`.
-    $path_readlink
-    ;;; The right to invoke `path_rename` with the file descriptor as the source directory.
-    $path_rename_source
-    ;;; The right to invoke `path_rename` with the file descriptor as the target directory.
-    $path_rename_target
-    ;;; The right to invoke `path_filestat_get`.
-    $path_filestat_get
-    ;;; The right to change a file's size.
-    ;;; If `path_open` is set, includes the right to invoke `path_open` with `oflags::trunc`.
-    ;;; Note: there is no function named `path_filestat_set_size`. This follows POSIX design,
-    ;;; which only has `ftruncate` and does not provide `ftruncateat`.
-    ;;; While such function would be desirable from the API design perspective, there are virtually
-    ;;; no use cases for it since no code written for POSIX systems would use it.
-    ;;; Moreover, implementing it would require multiple syscalls, leading to inferior performance.
-    $path_filestat_set_size
-    ;;; The right to invoke `path_filestat_set_times`.
-    $path_filestat_set_times
-    ;;; The right to invoke `path_permissions_set`.
-    $path_permissions_set
-    ;;; The right to invoke `fd_filestat_get`.
-    $fd_filestat_get
-    ;;; The right to invoke `fd_filestat_set_size`.
-    $fd_filestat_set_size
-    ;;; The right to invoke `fd_filestat_set_times`.
-    $fd_filestat_set_times
-    ;;; The right to invoke `fd_permissions_set`.
-    $fd_permissions_set
-    ;;; The right to invoke `path_symlink`.
-    $path_symlink
-    ;;; The right to invoke `path_remove_directory`.
-    $path_remove_directory
-    ;;; The right to invoke `path_unlink_file`.
-    $path_unlink_file
-    ;;; If `rights::fd_read` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype::fd_read`.
-    ;;; If `rights::fd_write` is set, includes the right to invoke `poll_oneoff` to subscribe to `eventtype::fd_write`.
-    $poll_fd_readwrite
-    ;;; The right to invoke `sock_shutdown`.
-    $sock_shutdown
+;;; Access mode for an open file descriptor handle.
+;;;
+;;; This describes whether a file descriptor may be used for reading,
+;;; writing, or both.
+;;;
+;;; This applies to sequences of bytes, and not directory entries.
+(typename $access_mode
+  (flags (@witx repr u8)
+    ;;; Reading (`read`, `pread`)
+    $read
+    ;;; Writing (`write`, `pwrite`, `filestat_set_size`, etc.).
+    $write
   )
 )
 
@@ -415,11 +342,8 @@
     (field $fs_filetype $filetype)
     ;;; File descriptor flags.
     (field $fs_flags $fdflags)
-    ;;; Rights that apply to this file descriptor.
-    (field $fs_rights_base $rights)
-    ;;; Maximum set of rights that may be installed on new file descriptors that
-    ;;; are created through this file descriptor, e.g., through `path_open`.
-    (field $fs_rights_inheriting $rights)
+    ;;; Access mode for this file descriptor.
+    (field $fs_access_mode $access_mode)
   )
 )
 


### PR DESCRIPTION
As discussed in #31, the `rights` type adds significant complexity both
for implementors and users, and isn't needed for POSIX compatibility.

Fixes #31.