### PR TITLE
Remove the `notcapable` errno code.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -616,10 +616,6 @@ Size: 1, Alignment: 1
 
   Cross-device link.
 
-- <a href="errno.notcapable" name="errno.notcapable"></a> [`notcapable`](#errno.notcapable)
-
-  Extension: Capabilities insufficient.
-
 ## <a href="#advice" name="advice"></a> `advice`: variant
 
   File or memory access pattern advisory information.

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -375,8 +375,6 @@ enum errno {
     txtbsy,
     /// Cross-device link.
     xdev,
-    /// Extension: Capabilities insufficient.
-    notcapable,
 }
 ```
 


### PR DESCRIPTION
Remove the `notcapable` errno code, also known as `ENOTCAPABLE`. This
errno code was previously used to indicate insufficient rights under
the rights system, however the rights system has been dropped, so this
errno code is no longer needed.