### PR TITLE
Change all identifiers to kebab-case.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -59,11 +59,11 @@ Size: 1, Alignment: 1
   The type of the descriptor or file is unknown or is different from
   any of the other types specified.
 
-- <a href="type.block_device" name="type.block_device"></a> [`block_device`](#type.block_device)
+- <a href="type.block_device" name="type.block_device"></a> [`block-device`](#type.block_device)
 
   The descriptor refers to a block device inode.
 
-- <a href="type.character_device" name="type.character_device"></a> [`character_device`](#type.character_device)
+- <a href="type.character_device" name="type.character_device"></a> [`character-device`](#type.character_device)
 
   The descriptor refers to a character device inode.
 
@@ -75,11 +75,11 @@ Size: 1, Alignment: 1
 
   The descriptor refers to a named pipe.
 
-- <a href="type.symbolic_link" name="type.symbolic_link"></a> [`symbolic_link`](#type.symbolic_link)
+- <a href="type.symbolic_link" name="type.symbolic_link"></a> [`symbolic-link`](#type.symbolic_link)
 
   The file refers to a symbolic link inode.
 
-- <a href="type.regular_file" name="type.regular_file"></a> [`regular_file`](#type.regular_file)
+- <a href="type.regular_file" name="type.regular_file"></a> [`regular-file`](#type.regular_file)
 
   The descriptor refers to a regular file inode.
 
@@ -91,7 +91,7 @@ Size: 1, Alignment: 1
 
   Descriptor flags.
   
-  Note: This was called `fdflags` in earlier versions of WASI.
+  Note: This was called `fd-flags` in earlier versions of WASI.
 
 Size: 1, Alignment: 1
 
@@ -179,7 +179,7 @@ Size: 64, Alignment: 8
 
   Last file status change timestamp.
 
-## <a href="#atflags" name="atflags"></a> `atflags`: record
+## <a href="#at_flags" name="at_flags"></a> `at-flags`: record
 
   Flags determining the method of how paths are resolved.
 
@@ -187,42 +187,42 @@ Size: 1, Alignment: 1
 
 ### Record Fields
 
-- <a href="atflags.symlink_follow" name="atflags.symlink_follow"></a> [`symlink_follow`](#atflags.symlink_follow): `bool`
+- <a href="at_flags.symlink_follow" name="at_flags.symlink_follow"></a> [`symlink-follow`](#at_flags.symlink_follow): `bool`
 
   As long as the resolved path corresponds to a symbolic link, it is expanded.
 Bit: 0
 
-## <a href="#oflags" name="oflags"></a> `oflags`: record
+## <a href="#o_flags" name="o_flags"></a> `o-flags`: record
 
-  Open flags used by `open_at`.
+  Open flags used by `open-at`.
 
 Size: 1, Alignment: 1
 
 ### Record Fields
 
-- <a href="oflags.create" name="oflags.create"></a> [`create`](#oflags.create): `bool`
+- <a href="o_flags.create" name="o_flags.create"></a> [`create`](#o_flags.create): `bool`
 
   Create file if it does not exist.
 Bit: 0
 
-- <a href="oflags.directory" name="oflags.directory"></a> [`directory`](#oflags.directory): `bool`
+- <a href="o_flags.directory" name="o_flags.directory"></a> [`directory`](#o_flags.directory): `bool`
 
   Fail if not a directory.
 Bit: 1
 
-- <a href="oflags.excl" name="oflags.excl"></a> [`excl`](#oflags.excl): `bool`
+- <a href="o_flags.excl" name="o_flags.excl"></a> [`excl`](#o_flags.excl): `bool`
 
   Fail if file already exists.
 Bit: 2
 
-- <a href="oflags.trunc" name="oflags.trunc"></a> [`trunc`](#oflags.trunc): `bool`
+- <a href="o_flags.trunc" name="o_flags.trunc"></a> [`trunc`](#o_flags.trunc): `bool`
 
   Truncate file to size 0.
 Bit: 3
 
 ## <a href="#mode" name="mode"></a> `mode`: record
 
-  Permissions mode used by `open_at`, `change_permissions_at`, and similar.
+  Permissions mode used by `open-at`, `change-permissions-at`, and similar.
 
 Size: 1, Alignment: 1
 
@@ -264,7 +264,7 @@ Size: 8, Alignment: 8
 
 Size: 8, Alignment: 8
 
-## <a href="#new_timestamp" name="new_timestamp"></a> `new_timestamp`: variant
+## <a href="#new_timestamp" name="new_timestamp"></a> `new-timestamp`: variant
 
   When setting a timestamp, this gives the value to set it to.
 
@@ -272,7 +272,7 @@ Size: 16, Alignment: 8
 
 ### Variant Cases
 
-- <a href="new_timestamp.no_change" name="new_timestamp.no_change"></a> [`no_change`](#new_timestamp.no_change)
+- <a href="new_timestamp.no_change" name="new_timestamp.no_change"></a> [`no-change`](#new_timestamp.no_change)
 
   Leave the timestamp set to its previous value.
 
@@ -652,7 +652,7 @@ Size: 1, Alignment: 1
 
   The application expects to access the specified data once and then not reuse it thereafter.
 
-## <a href="#seek_from" name="seek_from"></a> `seek_from`: variant
+## <a href="#seek_from" name="seek_from"></a> `seek-from`: variant
 
   The position relative to which to set the offset of the descriptor.
 
@@ -740,7 +740,7 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_set_size" name="descriptor_set_size"></a> `descriptor::set_size` 
+#### <a href="#descriptor_set_size" name="descriptor_set_size"></a> `descriptor::set-size` 
 
   Adjust the size of an open file. If this increases the file's size, the
   extra bytes are filled with zeros.
@@ -756,7 +756,7 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_set_times" name="descriptor_set_times"></a> `descriptor::set_times` 
+#### <a href="#descriptor_set_times" name="descriptor_set_times"></a> `descriptor::set-times` 
 
   Adjust the timestamps of an open file or directory.
   
@@ -766,8 +766,8 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_set_times.self" name="descriptor_set_times.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_set_times.atim" name="descriptor_set_times.atim"></a> `atim`: [`new_timestamp`](#new_timestamp)
-- <a href="#descriptor_set_times.mtim" name="descriptor_set_times.mtim"></a> `mtim`: [`new_timestamp`](#new_timestamp)
+- <a href="#descriptor_set_times.atim" name="descriptor_set_times.atim"></a> `atim`: [`new-timestamp`](#new_timestamp)
+- <a href="#descriptor_set_times.mtim" name="descriptor_set_times.mtim"></a> `mtim`: [`new-timestamp`](#new_timestamp)
 ##### Results
 
 - <a href="#descriptor_set_times." name="descriptor_set_times."></a> ``: expected<_, [`errno`](#errno)>
@@ -857,7 +857,7 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_seek.self" name="descriptor_seek.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_seek.from" name="descriptor_seek.from"></a> `from`: [`seek_from`](#seek_from)
+- <a href="#descriptor_seek.from" name="descriptor_seek.from"></a> `from`: [`seek-from`](#seek_from)
 ##### Results
 
 - <a href="#descriptor_seek." name="descriptor_seek."></a> ``: expected<[`filesize`](#filesize), [`errno`](#errno)>
@@ -907,7 +907,7 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_create_directory_at" name="descriptor_create_directory_at"></a> `descriptor::create_directory_at` 
+#### <a href="#descriptor_create_directory_at" name="descriptor_create_directory_at"></a> `descriptor::create-directory-at` 
 
   Create a directory.
   
@@ -922,7 +922,7 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_stat_at" name="descriptor_stat_at"></a> `descriptor::stat_at` 
+#### <a href="#descriptor_stat_at" name="descriptor_stat_at"></a> `descriptor::stat-at` 
 
   Return the attributes of a file or directory.
   
@@ -932,7 +932,7 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_stat_at.self" name="descriptor_stat_at.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_stat_at.atflags" name="descriptor_stat_at.atflags"></a> `atflags`: [`atflags`](#atflags)
+- <a href="#descriptor_stat_at.at_flags" name="descriptor_stat_at.at_flags"></a> `at-flags`: [`at-flags`](#at_flags)
 - <a href="#descriptor_stat_at.path" name="descriptor_stat_at.path"></a> `path`: `string`
 ##### Results
 
@@ -940,7 +940,7 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_set_times_at" name="descriptor_set_times_at"></a> `descriptor::set_times_at` 
+#### <a href="#descriptor_set_times_at" name="descriptor_set_times_at"></a> `descriptor::set-times-at` 
 
   Adjust the timestamps of a file or directory.
   
@@ -950,17 +950,17 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_set_times_at.self" name="descriptor_set_times_at.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_set_times_at.atflags" name="descriptor_set_times_at.atflags"></a> `atflags`: [`atflags`](#atflags)
+- <a href="#descriptor_set_times_at.at_flags" name="descriptor_set_times_at.at_flags"></a> `at-flags`: [`at-flags`](#at_flags)
 - <a href="#descriptor_set_times_at.path" name="descriptor_set_times_at.path"></a> `path`: `string`
-- <a href="#descriptor_set_times_at.atim" name="descriptor_set_times_at.atim"></a> `atim`: [`new_timestamp`](#new_timestamp)
-- <a href="#descriptor_set_times_at.mtim" name="descriptor_set_times_at.mtim"></a> `mtim`: [`new_timestamp`](#new_timestamp)
+- <a href="#descriptor_set_times_at.atim" name="descriptor_set_times_at.atim"></a> `atim`: [`new-timestamp`](#new_timestamp)
+- <a href="#descriptor_set_times_at.mtim" name="descriptor_set_times_at.mtim"></a> `mtim`: [`new-timestamp`](#new_timestamp)
 ##### Results
 
 - <a href="#descriptor_set_times_at." name="descriptor_set_times_at."></a> ``: expected<_, [`errno`](#errno)>
 
 ----
 
-#### <a href="#descriptor_link_at" name="descriptor_link_at"></a> `descriptor::link_at` 
+#### <a href="#descriptor_link_at" name="descriptor_link_at"></a> `descriptor::link-at` 
 
   Create a hard link.
   
@@ -968,17 +968,17 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_link_at.self" name="descriptor_link_at.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_link_at.old_atflags" name="descriptor_link_at.old_atflags"></a> `old_atflags`: [`atflags`](#atflags)
-- <a href="#descriptor_link_at.old_path" name="descriptor_link_at.old_path"></a> `old_path`: `string`
-- <a href="#descriptor_link_at.new_descriptor" name="descriptor_link_at.new_descriptor"></a> `new_descriptor`: handle<descriptor>
-- <a href="#descriptor_link_at.new_path" name="descriptor_link_at.new_path"></a> `new_path`: `string`
+- <a href="#descriptor_link_at.old_at_flags" name="descriptor_link_at.old_at_flags"></a> `old-at-flags`: [`at-flags`](#at_flags)
+- <a href="#descriptor_link_at.old_path" name="descriptor_link_at.old_path"></a> `old-path`: `string`
+- <a href="#descriptor_link_at.new_descriptor" name="descriptor_link_at.new_descriptor"></a> `new-descriptor`: handle<descriptor>
+- <a href="#descriptor_link_at.new_path" name="descriptor_link_at.new_path"></a> `new-path`: `string`
 ##### Results
 
 - <a href="#descriptor_link_at." name="descriptor_link_at."></a> ``: expected<_, [`errno`](#errno)>
 
 ----
 
-#### <a href="#descriptor_open_at" name="descriptor_open_at"></a> `descriptor::open_at` 
+#### <a href="#descriptor_open_at" name="descriptor_open_at"></a> `descriptor::open-at` 
 
   Open a file or directory.
   
@@ -992,10 +992,10 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_open_at.self" name="descriptor_open_at.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_open_at.atflags" name="descriptor_open_at.atflags"></a> `atflags`: [`atflags`](#atflags)
+- <a href="#descriptor_open_at.at_flags" name="descriptor_open_at.at_flags"></a> `at-flags`: [`at-flags`](#at_flags)
 - <a href="#descriptor_open_at.path" name="descriptor_open_at.path"></a> `path`: `string`
-- <a href="#descriptor_open_at.oflags" name="descriptor_open_at.oflags"></a> `oflags`: [`oflags`](#oflags)
-- <a href="#descriptor_open_at.fdflags" name="descriptor_open_at.fdflags"></a> `fdflags`: [`flags`](#flags)
+- <a href="#descriptor_open_at.o_flags" name="descriptor_open_at.o_flags"></a> `o-flags`: [`o-flags`](#o_flags)
+- <a href="#descriptor_open_at.fd_flags" name="descriptor_open_at.fd_flags"></a> `fd-flags`: [`flags`](#flags)
 - <a href="#descriptor_open_at.mode" name="descriptor_open_at.mode"></a> `mode`: [`mode`](#mode)
 ##### Results
 
@@ -1003,7 +1003,7 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_readlink_at" name="descriptor_readlink_at"></a> `descriptor::readlink_at` 
+#### <a href="#descriptor_readlink_at" name="descriptor_readlink_at"></a> `descriptor::readlink-at` 
 
   Read the contents of a symbolic link.
   
@@ -1018,7 +1018,7 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_remove_directory_at" name="descriptor_remove_directory_at"></a> `descriptor::remove_directory_at` 
+#### <a href="#descriptor_remove_directory_at" name="descriptor_remove_directory_at"></a> `descriptor::remove-directory-at` 
 
   Remove a directory.
   
@@ -1035,7 +1035,7 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_rename_at" name="descriptor_rename_at"></a> `descriptor::rename_at` 
+#### <a href="#descriptor_rename_at" name="descriptor_rename_at"></a> `descriptor::rename-at` 
 
   Rename a filesystem object.
   
@@ -1043,16 +1043,16 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_rename_at.self" name="descriptor_rename_at.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_rename_at.old_path" name="descriptor_rename_at.old_path"></a> `old_path`: `string`
-- <a href="#descriptor_rename_at.new_descriptor" name="descriptor_rename_at.new_descriptor"></a> `new_descriptor`: handle<descriptor>
-- <a href="#descriptor_rename_at.new_path" name="descriptor_rename_at.new_path"></a> `new_path`: `string`
+- <a href="#descriptor_rename_at.old_path" name="descriptor_rename_at.old_path"></a> `old-path`: `string`
+- <a href="#descriptor_rename_at.new_descriptor" name="descriptor_rename_at.new_descriptor"></a> `new-descriptor`: handle<descriptor>
+- <a href="#descriptor_rename_at.new_path" name="descriptor_rename_at.new_path"></a> `new-path`: `string`
 ##### Results
 
 - <a href="#descriptor_rename_at." name="descriptor_rename_at."></a> ``: expected<_, [`errno`](#errno)>
 
 ----
 
-#### <a href="#descriptor_symlink_at" name="descriptor_symlink_at"></a> `descriptor::symlink_at` 
+#### <a href="#descriptor_symlink_at" name="descriptor_symlink_at"></a> `descriptor::symlink-at` 
 
   Create a symbolic link.
   
@@ -1060,15 +1060,15 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_symlink_at.self" name="descriptor_symlink_at.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_symlink_at.old_path" name="descriptor_symlink_at.old_path"></a> `old_path`: `string`
-- <a href="#descriptor_symlink_at.new_path" name="descriptor_symlink_at.new_path"></a> `new_path`: `string`
+- <a href="#descriptor_symlink_at.old_path" name="descriptor_symlink_at.old_path"></a> `old-path`: `string`
+- <a href="#descriptor_symlink_at.new_path" name="descriptor_symlink_at.new_path"></a> `new-path`: `string`
 ##### Results
 
 - <a href="#descriptor_symlink_at." name="descriptor_symlink_at."></a> ``: expected<_, [`errno`](#errno)>
 
 ----
 
-#### <a href="#descriptor_unlink_file_at" name="descriptor_unlink_file_at"></a> `descriptor::unlink_file_at` 
+#### <a href="#descriptor_unlink_file_at" name="descriptor_unlink_file_at"></a> `descriptor::unlink-file-at` 
 
   Unlink a filesystem object that is not a directory.
   
@@ -1084,12 +1084,12 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_change_file_permissions_at" name="descriptor_change_file_permissions_at"></a> `descriptor::change_file_permissions_at` 
+#### <a href="#descriptor_change_file_permissions_at" name="descriptor_change_file_permissions_at"></a> `descriptor::change-file-permissions-at` 
 
 ##### Params
 
 - <a href="#descriptor_change_file_permissions_at.self" name="descriptor_change_file_permissions_at.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_change_file_permissions_at.atflags" name="descriptor_change_file_permissions_at.atflags"></a> `atflags`: [`atflags`](#atflags)
+- <a href="#descriptor_change_file_permissions_at.at_flags" name="descriptor_change_file_permissions_at.at_flags"></a> `at-flags`: [`at-flags`](#at_flags)
 - <a href="#descriptor_change_file_permissions_at.path" name="descriptor_change_file_permissions_at.path"></a> `path`: `string`
 - <a href="#descriptor_change_file_permissions_at.mode" name="descriptor_change_file_permissions_at.mode"></a> `mode`: [`mode`](#mode)
 ##### Results
@@ -1098,12 +1098,12 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_change_directory_permissions_at" name="descriptor_change_directory_permissions_at"></a> `descriptor::change_directory_permissions_at` 
+#### <a href="#descriptor_change_directory_permissions_at" name="descriptor_change_directory_permissions_at"></a> `descriptor::change-directory-permissions-at` 
 
 ##### Params
 
 - <a href="#descriptor_change_directory_permissions_at.self" name="descriptor_change_directory_permissions_at.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_change_directory_permissions_at.atflags" name="descriptor_change_directory_permissions_at.atflags"></a> `atflags`: [`atflags`](#atflags)
+- <a href="#descriptor_change_directory_permissions_at.at_flags" name="descriptor_change_directory_permissions_at.at_flags"></a> `at-flags`: [`at-flags`](#at_flags)
 - <a href="#descriptor_change_directory_permissions_at.path" name="descriptor_change_directory_permissions_at.path"></a> `path`: `string`
 - <a href="#descriptor_change_directory_permissions_at.mode" name="descriptor_change_directory_permissions_at.mode"></a> `mode`: [`mode`](#mode)
 ##### Results

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -63,17 +63,17 @@ enum "type" {
     /// any of the other types specified.
     unknown,
     /// The descriptor refers to a block device inode.
-    block_device,
+    block-device,
     /// The descriptor refers to a character device inode.
-    character_device,
+    character-device,
     /// The descriptor refers to a directory inode.
     directory,
     /// The descriptor refers to a named pipe.
     fifo,
     /// The file refers to a symbolic link inode.
-    symbolic_link,
+    symbolic-link,
     /// The descriptor refers to a regular file inode.
-    regular_file,
+    regular-file,
     /// The descriptor refers to a socket.
     socket,
 }
@@ -83,7 +83,7 @@ enum "type" {
 ```wit
 /// Descriptor flags.
 ///
-/// Note: This was called `fdflags` in earlier versions of WASI.
+/// Note: This was called `fd-flags` in earlier versions of WASI.
 flags "flags" {
     /// Read mode: Data can be read.
     read,
@@ -132,19 +132,19 @@ record stat {
 }
 ```
 
-## `atflags`
+## `at-flags`
 ```wit
 /// Flags determining the method of how paths are resolved.
-flags atflags {
+flags at-flags {
     /// As long as the resolved path corresponds to a symbolic link, it is expanded.
-    symlink_follow,
+    symlink-follow,
 }
 ```
 
-## `oflags`
+## `o-flags`
 ```wit
-/// Open flags used by `open_at`.
-flags oflags {
+/// Open flags used by `open-at`.
+flags o-flags {
     /// Create file if it does not exist.
     create,
     /// Fail if not a directory.
@@ -158,7 +158,7 @@ flags oflags {
 
 ## `mode`
 ```wit
-/// Permissions mode used by `open_at`, `change_permissions_at`, and similar.
+/// Permissions mode used by `open-at`, `change-permissions-at`, and similar.
 flags mode {
     /// True if the resource is considered readable by the containing
     /// filesystem.
@@ -191,12 +191,12 @@ type device = u64
 type inode = u64
 ```
 
-## `new_timestamp`
+## `new-timestamp`
 ```wit
 /// When setting a timestamp, this gives the value to set it to.
-variant new_timestamp {
+variant new-timestamp {
     /// Leave the timestamp set to its previous value.
-    no_change,
+    no-change,
     /// Set the timestamp to the current time of the system clock associated
     /// with the filesystem.
     now,
@@ -399,10 +399,10 @@ enum advice {
 }
 ```
 
-## `seek_from`
+## `seek-from`
 ```wit
 /// The position relative to which to set the offset of the descriptor.
-variant seek_from {
+variant seek-from {
     /// Seek relative to start-of-file.
     set(filesize),
     /// Seek relative to current position.
@@ -467,27 +467,27 @@ datasync: function() -> expected<_, errno>
 info: function() -> expected<info, errno>
 ```
 
-## `set_size`
+## `set-size`
 ```wit
 /// Adjust the size of an open file. If this increases the file's size, the
 /// extra bytes are filled with zeros.
 ///
 /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
-set_size: function(size: filesize) -> expected<_, errno>
+set-size: function(size: filesize) -> expected<_, errno>
 ```
 
-## `set_times`
+## `set-times`
 ```wit
 /// Adjust the timestamps of an open file or directory.
 ///
 /// Note: This is similar to `futimens` in POSIX.
 ///
 /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
-set_times: function(
+set-times: function(
     /// The desired values of the data access timestamp.
-    atim: new_timestamp,
+    atim: new-timestamp,
     /// The desired values of the data modification timestamp.
-    mtim: new_timestamp,
+    mtim: new-timestamp,
 ) -> expected<_, errno>
 ```
 
@@ -566,7 +566,7 @@ readdir: function(
 /// Note: This is similar to `lseek` in POSIX.
 seek: function(
     /// The method to compute the new offset.
-    "from": seek_from,
+    "from": seek-from,
 ) -> (
     /// The new offset of the descriptor, relative to the start of the file.
     expected<filesize, errno>
@@ -603,27 +603,27 @@ write: function(
 ) -> expected<size, errno>
 ```
 
-## `create_directory_at`
+## `create-directory-at`
 ```wit
 /// Create a directory.
 ///
 /// Note: This is similar to `mkdirat` in POSIX.
-create_directory_at: function(
+create-directory-at: function(
     /// The relative path at which to create the directory.
     path: string,
 ) -> expected<_, errno>
 ```
 
-## `stat_at`
+## `stat-at`
 ```wit
 /// Return the attributes of a file or directory.
 ///
 /// Note: This is similar to `fstatat` in POSIX.
 ///
 /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
-stat_at: function(
+stat-at: function(
     /// Flags determining the method of how the path is resolved.
-    atflags: atflags,
+    at-flags: at-flags,
     /// The relative path of the file or directory to inspect.
     path: string,
 ) -> (
@@ -632,43 +632,43 @@ stat_at: function(
 )
 ```
 
-## `set_times_at`
+## `set-times-at`
 ```wit
 /// Adjust the timestamps of a file or directory.
 ///
 /// Note: This is similar to `utimensat` in POSIX.
 ///
 /// Note: This was called `path_filestat_set_times` in earlier versions of WASI.
-set_times_at: function(
+set-times-at: function(
     /// Flags determining the method of how the path is resolved.
-    atflags: atflags,
+    at-flags: at-flags,
     /// The relative path of the file or directory to operate on.
     path: string,
     /// The desired values of the data access timestamp.
-    atim: new_timestamp,
+    atim: new-timestamp,
     /// The desired values of the data modification timestamp.
-    mtim: new_timestamp,
+    mtim: new-timestamp,
 ) -> expected<_, errno>
 ```
 
-## `link_at`
+## `link-at`
 ```wit
 /// Create a hard link.
 ///
 /// Note: This is similar to `linkat` in POSIX.
-link_at: function(
+link-at: function(
     /// Flags determining the method of how the path is resolved.
-    old_atflags: atflags,
+    old-at-flags: at-flags,
     /// The relative source path from which to link.
-    old_path: string,
-    /// The base directory for `new_path`.
-    new_descriptor: handle descriptor,
+    old-path: string,
+    /// The base directory for `new-path`.
+    new-descriptor: handle descriptor,
     /// The relative destination path at which to create the hard link.
-    new_path: string,
+    new-path: string,
 ) -> expected<_, errno>
 ```
 
-## `open_at`
+## `open-at`
 ```wit
 /// Open a file or directory.
 ///
@@ -679,15 +679,15 @@ link_at: function(
 /// guaranteed to be less than 2**31.
 ///
 /// Note: This is similar to `openat` in POSIX.
-open_at: function(
+open-at: function(
     /// Flags determining the method of how the path is resolved.
-    atflags: atflags,
+    at-flags: at-flags,
     /// The relative path of the object to open.
     path: string,
     /// The method by which to open the file.
-    oflags: oflags,
+    o-flags: o-flags,
     /// Flags to use for the resulting descriptor.
-    fdflags: "flags",
+    fd-flags: "flags",
     /// Permissions to use when creating a new file.
     mode: mode
 ) -> (
@@ -696,12 +696,12 @@ open_at: function(
 )
 ```
 
-## `readlink_at`
+## `readlink-at`
 ```wit
 /// Read the contents of a symbolic link.
 ///
 /// Note: This is similar to `readlinkat` in POSIX.
-readlink_at: function(
+readlink-at: function(
     /// The relative path of the symbolic link from which to read.
     path: string,
 ) -> (
@@ -710,60 +710,60 @@ readlink_at: function(
 )
 ```
 
-## `remove_directory_at`
+## `remove-directory-at`
 ```wit
 /// Remove a directory.
 ///
 /// Return `errno::notempty` if the directory is not empty.
 ///
 /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
-remove_directory_at: function(
+remove-directory-at: function(
     /// The relative path to a directory to remove.
     path: string,
 ) -> expected<_, errno>
 ```
 
-## `rename_at`
+## `rename-at`
 ```wit
 /// Rename a filesystem object.
 ///
 /// Note: This is similar to `renameat` in POSIX.
-rename_at: function(
+rename-at: function(
     /// The relative source path of the file or directory to rename.
-    old_path: string,
-    /// The base directory for `new_path`.
-    new_descriptor: handle descriptor,
+    old-path: string,
+    /// The base directory for `new-path`.
+    new-descriptor: handle descriptor,
     /// The relative destination path to which to rename the file or directory.
-    new_path: string,
+    new-path: string,
 ) -> expected<_, errno>
 ```
 
-## `symlink_at`
+## `symlink-at`
 ```wit
 /// Create a symbolic link.
 ///
 /// Note: This is similar to `symlinkat` in POSIX.
-symlink_at: function(
+symlink-at: function(
     /// The contents of the symbolic link.
-    old_path: string,
+    old-path: string,
     /// The relative destination path at which to create the symbolic link.
-    new_path: string,
+    new-path: string,
 ) -> expected<_, errno>
 ```
 
-## `unlink_file_at`
+## `unlink-file-at`
 ```wit
 /// Unlink a filesystem object that is not a directory.
 ///
 /// Return `errno::isdir` if the path refers to a directory.
 /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
-unlink_file_at: function(
+unlink-file-at: function(
     /// The relative path to a file to unlink.
     path: string,
 ) -> expected<_, errno>
 ```
 
-## `change_file_permissions_at`
+## `change-file-permissions-at`
 /// Change the permissions of a filesystem object that is not a directory.
 ///
 /// Note that the ultimate meanings of these permissions is
@@ -771,9 +771,9 @@ unlink_file_at: function(
 ///
 /// Note: This is similar to `fchmodat` in POSIX.
 ```wit
-change_file_permissions_at: function(
+change-file-permissions-at: function(
     /// Flags determining the method of how the path is resolved.
-    atflags: atflags,
+    at-flags: at-flags,
     /// The relative path to operate on.
     path: string,
     /// The new permissions for the filesystem object.
@@ -781,7 +781,7 @@ change_file_permissions_at: function(
 ) -> expected<_, errno>
 ```
 
-## `change_dir_permissions_at`
+## `change-dir-permissions-at`
 /// Change the permissions of a directory.
 ///
 /// Note that the ultimate meanings of these permissions is
@@ -793,9 +793,9 @@ change_file_permissions_at: function(
 ///
 /// Note: This is similar to `fchmodat` in POSIX.
 ```wit
-change_directory_permissions_at: function(
+change-directory-permissions-at: function(
     /// Flags determining the method of how the path is resolved.
-    atflags: atflags,
+    at-flags: at-flags,
     /// The relative path to operate on.
     path: string,
     /// The new permissions for the directory.


### PR DESCRIPTION
For consistency, pick a single naming convention and use it throughout
wasi-filesystem. This also anticipates an upcoming proposal to interface
types to require names to be kebab-case.