### PR TITLE
Update to wit-abi-up-to-date version v3.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: WebAssembly/wit-abi-up-to-date@v2
+    - uses: WebAssembly/wit-abi-up-to-date@v3
       with:
         wit-abi-tag: wit-abi-0.1.0


### PR DESCRIPTION
This adds --locked to the cargo install for `wit-abi`, which ensures
that we get the wit-bindgen it's known to work with.