### PR TITLE
Rename `open-at`'s `fd-flags` parameter to `flags`.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -993,7 +993,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_open_at.at_flags" name="descriptor_open_at.at_flags"></a> `at-flags`: [`at-flags`](#at_flags)
 - <a href="#descriptor_open_at.path" name="descriptor_open_at.path"></a> `path`: `string`
 - <a href="#descriptor_open_at.o_flags" name="descriptor_open_at.o_flags"></a> `o-flags`: [`o-flags`](#o_flags)
-- <a href="#descriptor_open_at.fd_flags" name="descriptor_open_at.fd_flags"></a> `fd-flags`: [`flags`](#flags)
+- <a href="#descriptor_open_at.flags" name="descriptor_open_at.flags"></a> `flags`: [`flags`](#flags)
 - <a href="#descriptor_open_at.mode" name="descriptor_open_at.mode"></a> `mode`: [`mode`](#mode)
 ##### Result
 

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -667,7 +667,7 @@ open-at: func(
     /// The method by which to open the file.
     o-flags: o-flags,
     /// Flags to use for the resulting descriptor.
-    fd-flags: %flags,
+    %flags: %flags,
     /// Permissions to use when creating a new file.
     mode: mode
 ) -> expected<descriptor, errno>


### PR DESCRIPTION
This matches how the `fd-flags` type was renamed to `flags`.

This effectively incorporates the main change from #40.

Co-authored-by: Yonggang Luo <luoyonggang@gmail.com>