### PR TITLE
Remove the `read` and `write` functions.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -802,22 +802,6 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_read" name="descriptor_read"></a> `descriptor::read` 
-
-  Read from a descriptor.
-  
-  The meaning of `read` on a directory is unspecified.
-  
-  Note: This is similar to `read` in POSIX.
-##### Params
-
-- <a href="#descriptor_read.self" name="descriptor_read.self"></a> `self`: handle<descriptor>
-##### Result
-
-- stream<`u8`, [`errno`](#errno)>
-
-----
-
 #### <a href="#descriptor_readdir" name="descriptor_readdir"></a> `descriptor::readdir` 
 
   Read directory entries from a directory.
@@ -887,21 +871,6 @@ Size: 16, Alignment: 8
 ##### Result
 
 - expected<[`filesize`](#filesize), [`errno`](#errno)>
-
-----
-
-#### <a href="#descriptor_write" name="descriptor_write"></a> `descriptor::write` 
-
-  Write to a descriptor.
-  
-  Note: This is similar to `write` in POSIX.
-##### Params
-
-- <a href="#descriptor_write.self" name="descriptor_write.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_write.buf" name="descriptor_write.buf"></a> `buf`: stream<`u8`, `unit`>
-##### Result
-
-- future<expected<`unit`, [`errno`](#errno)>>
 
 ----
 

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -513,16 +513,6 @@ pwrite: func(
 ) -> future<expected<unit, errno>>
 ```
 
-## `read`
-```wit
-/// Read from a descriptor.
-///
-/// The meaning of `read` on a directory is unspecified.
-///
-/// Note: This is similar to `read` in POSIX.
-read: func() -> stream<u8, errno>
-```
-
 ## `readdir`
 ```wit
 /// Read directory entries from a directory.
@@ -573,17 +563,6 @@ sync: func() -> expected<unit, errno>
 ///
 /// Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
 tell: func() -> expected<filesize, errno>
-```
-
-## `write`
-```wit
-/// Write to a descriptor.
-///
-/// Note: This is similar to `write` in POSIX.
-write: func(
-    /// Data to write
-    buf: stream<u8, unit>,
-) -> future<expected<unit, errno>>
 ```
 
 ## `create-directory-at`


### PR DESCRIPTION
We can implement libc `read` and `write` using `pread` and `pwrite` and
using the streams to stream through files. And this simplifies the
`descriptor` resource, as it no longer needs an exposed "current
position" state.