### PR TITLE
Remove the `success` errno field.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -317,10 +317,6 @@ Size: 1, Alignment: 1
 
 ### Enum Cases
 
-- <a href="errno.success" name="errno.success"></a> [`success`](#errno.success)
-
-  No error occurred. System call completed successfully.
-
 - <a href="errno.toobig" name="errno.toobig"></a> [`toobig`](#errno.toobig)
 
   Argument list too long. This is similar to `E2BIG` in POSIX.

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -225,8 +225,6 @@ record dirent {
 /// API; some are used in higher-level library layers, and others are provided
 /// merely for alignment with POSIX.
 enum errno {
-    /// No error occurred. System call completed successfully.
-    success,
     /// Argument list too long. This is similar to `E2BIG` in POSIX.
     toobig,
     /// Permission denied.


### PR DESCRIPTION
We now use the `expected` type to report errors, so we no longer need a
success field in the wasi-filesystem errno enum.

wasi-libc will be synthesizing its own `errno` value to present a POSIX
abstraction, so it doesn't depend on having a zero "success" value in
this enum.

Fixes #54.