### PR TITLE
Remove unused `errno` values, and document others.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -385,13 +385,9 @@ Size: 1, Alignment: 1
 
   Destination address required.
 
-- <a href="errno.dom" name="errno.dom"></a> [`dom`](#errno.dom)
-
-  Mathematics argument out of domain of function.
-
 - <a href="errno.dquot" name="errno.dquot"></a> [`dquot`](#errno.dquot)
 
-  Reserved.
+  Storage quota exceeded.
 
 - <a href="errno.exist" name="errno.exist"></a> [`exist`](#errno.exist)
 
@@ -459,7 +455,7 @@ Size: 1, Alignment: 1
 
 - <a href="errno.multihop" name="errno.multihop"></a> [`multihop`](#errno.multihop)
 
-  Reserved.
+  Multihop attempted.
 
 - <a href="errno.nametoolong" name="errno.nametoolong"></a> [`nametoolong`](#errno.nametoolong)
 
@@ -503,7 +499,7 @@ Size: 1, Alignment: 1
 
 - <a href="errno.nolink" name="errno.nolink"></a> [`nolink`](#errno.nolink)
 
-  Reserved.
+  Link has been severed.
 
 - <a href="errno.nomem" name="errno.nomem"></a> [`nomem`](#errno.nomem)
 
@@ -525,10 +521,6 @@ Size: 1, Alignment: 1
 
   Function not supported.
 
-- <a href="errno.notconn" name="errno.notconn"></a> [`notconn`](#errno.notconn)
-
-  The socket is not connected.
-
 - <a href="errno.notdir" name="errno.notdir"></a> [`notdir`](#errno.notdir)
 
   Not a directory or a symbolic link to a directory.
@@ -540,10 +532,6 @@ Size: 1, Alignment: 1
 - <a href="errno.notrecoverable" name="errno.notrecoverable"></a> [`notrecoverable`](#errno.notrecoverable)
 
   State not recoverable.
-
-- <a href="errno.notsock" name="errno.notsock"></a> [`notsock`](#errno.notsock)
-
-  Not a socket.
 
 - <a href="errno.notsup" name="errno.notsup"></a> [`notsup`](#errno.notsup)
 
@@ -573,18 +561,6 @@ Size: 1, Alignment: 1
 
   Broken pipe.
 
-- <a href="errno.proto" name="errno.proto"></a> [`proto`](#errno.proto)
-
-  Protocol error.
-
-- <a href="errno.protonosupport" name="errno.protonosupport"></a> [`protonosupport`](#errno.protonosupport)
-
-  Protocol not supported.
-
-- <a href="errno.prototype" name="errno.prototype"></a> [`prototype`](#errno.prototype)
-
-  Protocol wrong type for socket.
-
 - <a href="errno.range" name="errno.range"></a> [`range`](#errno.range)
 
   Result too large.
@@ -603,7 +579,7 @@ Size: 1, Alignment: 1
 
 - <a href="errno.stale" name="errno.stale"></a> [`stale`](#errno.stale)
 
-  Reserved.
+  Stale file handle.
 
 - <a href="errno.timedout" name="errno.timedout"></a> [`timedout`](#errno.timedout)
 

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -259,9 +259,7 @@ enum errno {
     deadlk,
     /// Destination address required.
     destaddrreq,
-    /// Mathematics argument out of domain of function.
-    dom,
-    /// Reserved.
+    /// Storage quota exceeded.
     dquot,
     /// File exists.
     exist,
@@ -295,7 +293,7 @@ enum errno {
     mlink,
     /// Message too large.
     msgsize,
-    /// Reserved.
+    /// Multihop attempted.
     multihop,
     /// Filename too long.
     nametoolong,
@@ -317,7 +315,7 @@ enum errno {
     noexec,
     /// No locks available.
     nolck,
-    /// Reserved.
+    /// Link has been severed.
     nolink,
     /// Not enough space.
     nomem,
@@ -329,16 +327,12 @@ enum errno {
     nospc,
     /// Function not supported.
     nosys,
-    /// The socket is not connected.
-    notconn,
     /// Not a directory or a symbolic link to a directory.
     notdir,
     /// Directory not empty.
     notempty,
     /// State not recoverable.
     notrecoverable,
-    /// Not a socket.
-    notsock,
     /// Not supported, or operation not supported on socket.
     notsup,
     /// Inappropriate I/O control operation.
@@ -353,12 +347,6 @@ enum errno {
     perm,
     /// Broken pipe.
     pipe,
-    /// Protocol error.
-    proto,
-    /// Protocol not supported.
-    protonosupport,
-    /// Protocol wrong type for socket.
-    prototype,
     /// Result too large.
     range,
     /// Read-only file system.
@@ -367,7 +355,7 @@ enum errno {
     spipe,
     /// No such process.
     srch,
-    /// Reserved.
+    /// Stale file handle.
     stale,
     /// Connection timed out.
     timedout,


### PR DESCRIPTION
Remove `dom`, `notconn`, `notsock`, `proto`, `protonosupport`, and
`prototype` from the wasi-filesystem `errno` enum. These codes aren't
used by filesystem APIs. wasi-libc will be synthesizing its own errno
code, so we don't need wasi-filesystem to have errno codes that it
itself isn't using.

Fixes #29.