### PR TITLE
Fix the docs for `info` to reference the correct POSIX function.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -724,7 +724,7 @@ Size: 16, Alignment: 8
 
   Get information associated with a descriptor.
   
-  Note: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well
+  Note: This returns similar flags to `fcntl(fd, F_GETFL)` in POSIX, as well
   as additional fields.
   
   Note: This was called `fdstat_get` in earlier versions of WASI.

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -458,7 +458,7 @@ datasync: func() -> expected<unit, errno>
 ```wit
 /// Get information associated with a descriptor.
 ///
-/// Note: This returns similar flags to `fsync(fd, F_GETFL)` in POSIX, as well
+/// Note: This returns similar flags to `fcntl(fd, F_GETFL)` in POSIX, as well
 /// as additional fields.
 ///
 /// Note: This was called `fdstat_get` in earlier versions of WASI.


### PR DESCRIPTION
Say `fcntl` instead of `fsync`, as the corresponding POSIX function to
the `info` function.

Fixes #22.