### PR TITLE
Update wit syntax to match the latest wit-bindgen.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -273,11 +273,11 @@ Size: 16, Alignment: 8
 
 ### Variant Cases
 
-- <a href="new_timestamp.no_change" name="new_timestamp.no_change"></a> [`no-change`](#new_timestamp.no_change): `unit`
+- <a href="new_timestamp.no_change" name="new_timestamp.no_change"></a> [`no-change`](#new_timestamp.no_change)
 
   Leave the timestamp set to its previous value.
 
-- <a href="new_timestamp.now" name="new_timestamp.now"></a> [`now`](#new_timestamp.now): `unit`
+- <a href="new_timestamp.now" name="new_timestamp.now"></a> [`now`](#new_timestamp.now)
 
   Set the timestamp to the current time of the system clock associated
   with the filesystem.
@@ -658,7 +658,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_fadvise.advice" name="descriptor_fadvise.advice"></a> `advice`: [`advice`](#advice)
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -674,7 +674,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_fallocate.len" name="descriptor_fallocate.len"></a> `len`: [`filesize`](#filesize)
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -688,7 +688,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_datasync.self" name="descriptor_datasync.self"></a> `self`: handle<descriptor>
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -705,7 +705,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_info.self" name="descriptor_info.self"></a> `self`: handle<descriptor>
 ##### Result
 
-- expected<[`info`](#info), [`errno`](#errno)>
+- result<[`info`](#info), [`errno`](#errno)>
 
 ----
 
@@ -721,7 +721,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_set_size.size" name="descriptor_set_size.size"></a> `size`: [`filesize`](#filesize)
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -739,7 +739,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_set_times.mtim" name="descriptor_set_times.mtim"></a> `mtim`: [`new-timestamp`](#new_timestamp)
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -766,11 +766,11 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_pwrite.self" name="descriptor_pwrite.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_pwrite.buf" name="descriptor_pwrite.buf"></a> `buf`: stream<`u8`, `unit`>
+- <a href="#descriptor_pwrite.buf" name="descriptor_pwrite.buf"></a> `buf`: stream<`u8`>
 - <a href="#descriptor_pwrite.offset" name="descriptor_pwrite.offset"></a> `offset`: [`filesize`](#filesize)
 ##### Result
 
-- future<expected<`unit`, [`errno`](#errno)>>
+- future<result<_, [`errno`](#errno)>>
 
 ----
 
@@ -812,7 +812,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_seek.from" name="descriptor_seek.from"></a> `from`: [`seek-from`](#seek_from)
 ##### Result
 
-- expected<[`filesize`](#filesize), [`errno`](#errno)>
+- result<[`filesize`](#filesize), [`errno`](#errno)>
 
 ----
 
@@ -826,7 +826,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_sync.self" name="descriptor_sync.self"></a> `self`: handle<descriptor>
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -842,7 +842,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_tell.self" name="descriptor_tell.self"></a> `self`: handle<descriptor>
 ##### Result
 
-- expected<[`filesize`](#filesize), [`errno`](#errno)>
+- result<[`filesize`](#filesize), [`errno`](#errno)>
 
 ----
 
@@ -857,7 +857,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_create_directory_at.path" name="descriptor_create_directory_at.path"></a> `path`: `string`
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -875,7 +875,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_stat_at.path" name="descriptor_stat_at.path"></a> `path`: `string`
 ##### Result
 
-- expected<[`stat`](#stat), [`errno`](#errno)>
+- result<[`stat`](#stat), [`errno`](#errno)>
 
 ----
 
@@ -895,7 +895,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_set_times_at.mtim" name="descriptor_set_times_at.mtim"></a> `mtim`: [`new-timestamp`](#new_timestamp)
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -913,7 +913,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_link_at.new_path" name="descriptor_link_at.new_path"></a> `new-path`: `string`
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -938,7 +938,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_open_at.mode" name="descriptor_open_at.mode"></a> `mode`: [`mode`](#mode)
 ##### Result
 
-- expected<handle<descriptor>, [`errno`](#errno)>
+- result<handle<descriptor>, [`errno`](#errno)>
 
 ----
 
@@ -953,7 +953,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_readlink_at.path" name="descriptor_readlink_at.path"></a> `path`: `string`
 ##### Result
 
-- expected<`string`, [`errno`](#errno)>
+- result<`string`, [`errno`](#errno)>
 
 ----
 
@@ -970,7 +970,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_remove_directory_at.path" name="descriptor_remove_directory_at.path"></a> `path`: `string`
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -987,7 +987,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_rename_at.new_path" name="descriptor_rename_at.new_path"></a> `new-path`: `string`
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -1003,7 +1003,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_symlink_at.new_path" name="descriptor_symlink_at.new_path"></a> `new-path`: `string`
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -1019,7 +1019,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_unlink_file_at.path" name="descriptor_unlink_file_at.path"></a> `path`: `string`
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -1039,7 +1039,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_change_file_permissions_at.mode" name="descriptor_change_file_permissions_at.mode"></a> `mode`: [`mode`](#mode)
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 
 ----
 
@@ -1063,5 +1063,5 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_change_directory_permissions_at.mode" name="descriptor_change_directory_permissions_at.mode"></a> `mode`: [`mode`](#mode)
 ##### Result
 
-- expected<`unit`, [`errno`](#errno)>
+- result<_, [`errno`](#errno)>
 

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -416,7 +416,7 @@ fadvise: func(
     len: u64,
     /// The advice.
     advice: advice
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ## `fallocate`
@@ -429,7 +429,7 @@ fallocate: func(
     offset: filesize,
     /// The length of the area that is allocated.
     len: filesize
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ## `fdatasync`
@@ -437,7 +437,7 @@ fallocate: func(
 /// Synchronize the data of a file to disk.
 ///
 /// Note: This is similar to `fdatasync` in POSIX.
-datasync: func() -> expected<unit, errno>
+datasync: func() -> result<_, errno>
 ```
 
 ## `info`
@@ -448,7 +448,7 @@ datasync: func() -> expected<unit, errno>
 /// as additional fields.
 ///
 /// Note: This was called `fdstat_get` in earlier versions of WASI.
-info: func() -> expected<info, errno>
+info: func() -> result<info, errno>
 ```
 
 ## `set-size`
@@ -457,7 +457,7 @@ info: func() -> expected<info, errno>
 /// extra bytes are filled with zeros.
 ///
 /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
-set-size: func(size: filesize) -> expected<unit, errno>
+set-size: func(size: filesize) -> result<_, errno>
 ```
 
 ## `set-times`
@@ -472,7 +472,7 @@ set-times: func(
     atim: new-timestamp,
     /// The desired values of the data modification timestamp.
     mtim: new-timestamp,
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ## `pread`
@@ -493,10 +493,10 @@ pread: func(
 /// Note: This is similar to `pwrite` in POSIX.
 pwrite: func(
     /// Data to write
-    buf: stream<u8, unit>,
+    buf: stream<u8>,
     /// The offset within the file at which to write.
     offset: filesize,
-) -> future<expected<unit, errno>>
+) -> future<result<_, errno>>
 ```
 
 ## `readdir`
@@ -530,7 +530,7 @@ readdir: func(
 seek: func(
     /// The method to compute the new offset.
     %from: seek-from,
-) -> expected<filesize, errno>
+) -> result<filesize, errno>
 ```
 
 ## `sync`
@@ -538,7 +538,7 @@ seek: func(
 /// Synchronize the data and metadata of a file to disk.
 ///
 /// Note: This is similar to `fsync` in POSIX.
-sync: func() -> expected<unit, errno>
+sync: func() -> result<_, errno>
 ```
 
 ## `tell`
@@ -548,7 +548,7 @@ sync: func() -> expected<unit, errno>
 /// Returns the current offset of the descriptor, relative to the start of the file.
 ///
 /// Note: This is similar to `lseek(fd, 0, SEEK_CUR)` in POSIX.
-tell: func() -> expected<filesize, errno>
+tell: func() -> result<filesize, errno>
 ```
 
 ## `create-directory-at`
@@ -559,7 +559,7 @@ tell: func() -> expected<filesize, errno>
 create-directory-at: func(
     /// The relative path at which to create the directory.
     path: string,
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ## `stat-at`
@@ -574,7 +574,7 @@ stat-at: func(
     at-flags: at-flags,
     /// The relative path of the file or directory to inspect.
     path: string,
-) -> expected<stat, errno>
+) -> result<stat, errno>
 ```
 
 ## `set-times-at`
@@ -593,7 +593,7 @@ set-times-at: func(
     atim: new-timestamp,
     /// The desired values of the data modification timestamp.
     mtim: new-timestamp,
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ## `link-at`
@@ -610,7 +610,7 @@ link-at: func(
     new-descriptor: handle descriptor,
     /// The relative destination path at which to create the hard link.
     new-path: string,
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ## `open-at`
@@ -635,7 +635,7 @@ open-at: func(
     %flags: %flags,
     /// Permissions to use when creating a new file.
     mode: mode
-) -> expected<descriptor, errno>
+) -> result<descriptor, errno>
 ```
 
 ## `readlink-at`
@@ -646,7 +646,7 @@ open-at: func(
 readlink-at: func(
     /// The relative path of the symbolic link from which to read.
     path: string,
-) -> expected<string, errno>
+) -> result<string, errno>
 ```
 
 ## `remove-directory-at`
@@ -659,7 +659,7 @@ readlink-at: func(
 remove-directory-at: func(
     /// The relative path to a directory to remove.
     path: string,
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ## `rename-at`
@@ -674,7 +674,7 @@ rename-at: func(
     new-descriptor: handle descriptor,
     /// The relative destination path to which to rename the file or directory.
     new-path: string,
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ## `symlink-at`
@@ -687,7 +687,7 @@ symlink-at: func(
     old-path: string,
     /// The relative destination path at which to create the symbolic link.
     new-path: string,
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ## `unlink-file-at`
@@ -699,7 +699,7 @@ symlink-at: func(
 unlink-file-at: func(
     /// The relative path to a file to unlink.
     path: string,
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ## `change-file-permissions-at`
@@ -717,7 +717,7 @@ change-file-permissions-at: func(
     path: string,
     /// The new permissions for the filesystem object.
     mode: mode,
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ## `change-dir-permissions-at`
@@ -739,7 +739,7 @@ change-directory-permissions-at: func(
     path: string,
     /// The new permissions for the directory.
     mode: mode,
-) -> expected<unit, errno>
+) -> result<_, errno>
 ```
 
 ```wit


### PR DESCRIPTION
This invvolves the removal of the `unit` type, renaming `expected` to `result`.