### PR TITLE
Re-introduce the `badf` filesystem error code.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -345,6 +345,10 @@ Size: 1, Alignment: 1
 
   Connection already in progress.
 
+- <a href="errno.badf" name="errno.badf"></a> [`badf`](#errno.badf)
+
+  Bad file descriptor.
+
 - <a href="errno.badmsg" name="errno.badmsg"></a> [`badmsg`](#errno.badmsg)
 
   Bad message.

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -239,6 +239,8 @@ enum errno {
     again,
     /// Connection already in progress.
     already,
+    /// Bad file descriptor.
+    badf,
     /// Bad message.
     badmsg,
     /// Device or resource busy.


### PR DESCRIPTION
POSIX overloads `EBADF` with two meanings: file descriptor out of bounds, and attempt to read or write on a device that doesn't support reading or writing, respectively. In WASI, the former meaning is being handled at the WIT level, but the latter meaning still applies, so reintroduce `badf` as an error code.