### PR TITLE
Add byte lengths to `pread` and `pwrite`.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -751,6 +751,7 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_pread.self" name="descriptor_pread.self"></a> `self`: handle<descriptor>
+- <a href="#descriptor_pread.len" name="descriptor_pread.len"></a> `len`: [`size`](#size)
 - <a href="#descriptor_pread.offset" name="descriptor_pread.offset"></a> `offset`: [`filesize`](#filesize)
 ##### Results
 
@@ -770,7 +771,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_pwrite.offset" name="descriptor_pwrite.offset"></a> `offset`: [`filesize`](#filesize)
 ##### Results
 
-- future<result<_, [`errno`](#errno)>>
+- future<result<[`size`](#size), [`errno`](#errno)>>
 
 ----
 

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -481,6 +481,8 @@ set-times: func(
 ///
 /// Note: This is similar to `pread` in POSIX.
 pread: func(
+    /// The maximim number of bytes to read.
+    len: size,
     /// The offset within the file at which to read.
     offset: filesize,
 ) -> stream<u8, errno>
@@ -496,7 +498,7 @@ pwrite: func(
     buf: stream<u8>,
     /// The offset within the file at which to write.
     offset: filesize,
-) -> future<result<_, errno>>
+) -> future<result<size, errno>>
 ```
 
 ## `readdir`


### PR DESCRIPTION
Add a length parameter to `pread` to specify how many bytes to attempt to read, as otherwise there's no way for it to know how many bytes to read.

Similarly, add a length result to `pwrite` indicating how many bytes were written, since there's otherwise no other indication of the number of bytes written.