### PR TITLE
Rename `info` to `fd-info`, and other minor fixes.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -657,8 +657,8 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_fadvise.self" name="descriptor_fadvise.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_fadvise.offset" name="descriptor_fadvise.offset"></a> `offset`: `u64`
-- <a href="#descriptor_fadvise.len" name="descriptor_fadvise.len"></a> `len`: `u64`
+- <a href="#descriptor_fadvise.offset" name="descriptor_fadvise.offset"></a> `offset`: [`filesize`](#filesize)
+- <a href="#descriptor_fadvise.len" name="descriptor_fadvise.len"></a> `len`: [`size`](#size)
 - <a href="#descriptor_fadvise.advice" name="descriptor_fadvise.advice"></a> `advice`: [`advice`](#advice)
 ##### Results
 
@@ -680,7 +680,7 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_info" name="descriptor_info"></a> `descriptor::info` 
+#### <a href="#descriptor_fd_info" name="descriptor_fd_info"></a> `descriptor::fd-info` 
 
   Get information associated with a descriptor.
   
@@ -690,7 +690,7 @@ Size: 16, Alignment: 8
   Note: This was called `fdstat_get` in earlier versions of WASI.
 ##### Params
 
-- <a href="#descriptor_info.self" name="descriptor_info.self"></a> `self`: handle<descriptor>
+- <a href="#descriptor_fd_info.self" name="descriptor_fd_info.self"></a> `self`: handle<descriptor>
 ##### Results
 
 - result<[`info`](#info), [`errno`](#errno)>

--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -26,7 +26,7 @@ Size: 8, Alignment: 8
 
 Size: 8, Alignment: 8
 
-## <a href="#info" name="info"></a> `info`: record
+## <a href="#fd_info" name="fd_info"></a> `fd-info`: record
 
   Information associated with a descriptor.
   
@@ -36,11 +36,11 @@ Size: 2, Alignment: 1
 
 ### Record Fields
 
-- <a href="info.type" name="info.type"></a> [`type`](#info.type): [`type`](#type)
+- <a href="fd_info.type" name="fd_info.type"></a> [`type`](#fd_info.type): [`type`](#type)
 
   The type of filesystem object referenced by a descriptor.
 
-- <a href="info.flags" name="info.flags"></a> [`flags`](#info.flags): [`flags`](#flags)
+- <a href="fd_info.flags" name="fd_info.flags"></a> [`flags`](#fd_info.flags): [`flags`](#flags)
 
   Flags associated with a descriptor.
 
@@ -680,7 +680,7 @@ Size: 16, Alignment: 8
 
 ----
 
-#### <a href="#descriptor_fd_info" name="descriptor_fd_info"></a> `descriptor::fd-info` 
+#### <a href="#descriptor_info" name="descriptor_info"></a> `descriptor::info` 
 
   Get information associated with a descriptor.
   
@@ -690,10 +690,10 @@ Size: 16, Alignment: 8
   Note: This was called `fdstat_get` in earlier versions of WASI.
 ##### Params
 
-- <a href="#descriptor_fd_info.self" name="descriptor_fd_info.self"></a> `self`: handle<descriptor>
+- <a href="#descriptor_info.self" name="descriptor_info.self"></a> `self`: handle<descriptor>
 ##### Results
 
-- result<[`info`](#info), [`errno`](#errno)>
+- result<[`fd-info`](#fd_info), [`errno`](#errno)>
 
 ----
 

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -40,12 +40,12 @@ type filedelta = s64
 type timestamp = u64
 ```
 
-## `info`
+## `fd-info`
 ```wit
 /// Information associated with a descriptor.
 ///
 /// Note: This was called `fdstat` in earlier versions of WASI.
-record info {
+record fd-info {
     /// The type of filesystem object referenced by a descriptor.
     %type: %type,
     /// Flags associated with a descriptor.
@@ -429,7 +429,7 @@ fadvise: func(
 datasync: func() -> result<_, errno>
 ```
 
-## `fd-info`
+## `info`
 ```wit
 /// Get information associated with a descriptor.
 ///
@@ -437,7 +437,7 @@ datasync: func() -> result<_, errno>
 /// as additional fields.
 ///
 /// Note: This was called `fdstat_get` in earlier versions of WASI.
-fd-info: func() -> result<info, errno>
+info: func() -> result<fd-info, errno>
 ```
 
 ## `set-size`

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -413,15 +413,15 @@ resource descriptor {
 /// This is similar to `posix_fadvise` in POSIX.
 fadvise: func(
     /// The offset within the file to which the advisory applies.
-    offset: u64,
+    offset: filesize,
     /// The length of the region to which the advisory applies.
-    len: u64,
+    len: size,
     /// The advice.
     advice: advice
 ) -> result<_, errno>
 ```
 
-## `fdatasync`
+## `datasync`
 ```wit
 /// Synchronize the data of a file to disk.
 ///
@@ -429,7 +429,7 @@ fadvise: func(
 datasync: func() -> result<_, errno>
 ```
 
-## `info`
+## `fd-info`
 ```wit
 /// Get information associated with a descriptor.
 ///
@@ -437,7 +437,7 @@ datasync: func() -> result<_, errno>
 /// as additional fields.
 ///
 /// Note: This was called `fdstat_get` in earlier versions of WASI.
-info: func() -> result<info, errno>
+fd-info: func() -> result<info, errno>
 ```
 
 ## `set-size`


### PR DESCRIPTION
Rename the `info` function to `fd-info`, to avoid a name collision with the `info` type.

While here, also fix the documentation name for the `datasync` function. And use `filesize` and for fadvise arguments.