### PR TITLE
Document the behavior of writes past the end of a file.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -776,6 +776,10 @@ Size: 16, Alignment: 8
 
   Write to a descriptor, without using and updating the descriptor's offset.
   
+  It is valid to write past the end of a file; the file is extended to the
+  extent of the write, with bytes between the previous end and the start of
+  the write set to zero.
+  
   Note: This is similar to `pwrite` in POSIX.
 ##### Params
 
@@ -805,11 +809,17 @@ Size: 16, Alignment: 8
 
 #### <a href="#descriptor_seek" name="descriptor_seek"></a> `descriptor::seek` 
 
-  Move the offset of a descriptor.
+  Move the offset of a file descriptor.
   
-  The meaning of `seek` on a directory is unspecified.
+  If the descriptor refers to a directory, this function fails with
+  `errno::spipe`.
   
   Returns new offset of the descriptor, relative to the start of the file.
+  
+  It is valid to seek past the end of a file. The file size is not modified
+  until a write is performed, at which time the file is extended to the
+  extent of the write, with bytes between the previous end and the start of
+  the write set to zero.
   
   Note: This is similar to `lseek` in POSIX.
 ##### Params
@@ -839,6 +849,9 @@ Size: 16, Alignment: 8
 #### <a href="#descriptor_tell" name="descriptor_tell"></a> `descriptor::tell` 
 
   Return the current offset of a descriptor.
+  
+  If the descriptor refers to a directory, this function fails with
+  `errno::spipe`.
   
   Returns the current offset of the descriptor, relative to the start of the file.
   

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -497,6 +497,10 @@ pread: func(
 ```wit
 /// Write to a descriptor, without using and updating the descriptor's offset.
 ///
+/// It is valid to write past the end of a file; the file is extended to the
+/// extent of the write, with bytes between the previous end and the start of
+/// the write set to zero.
+///
 /// Note: This is similar to `pwrite` in POSIX.
 pwrite: func(
     /// Data to write
@@ -517,11 +521,17 @@ readdir: func() -> stream<dir-entry, errno>
 
 ## `seek`
 ```wit
-/// Move the offset of a descriptor.
+/// Move the offset of a file descriptor.
 ///
-/// The meaning of `seek` on a directory is unspecified.
+/// If the descriptor refers to a directory, this function fails with
+/// `errno::spipe`.
 ///
 /// Returns new offset of the descriptor, relative to the start of the file.
+///
+/// It is valid to seek past the end of a file. The file size is not modified
+/// until a write is performed, at which time the file is extended to the
+/// extent of the write, with bytes between the previous end and the start of
+/// the write set to zero.
 ///
 /// Note: This is similar to `lseek` in POSIX.
 seek: func(
@@ -541,6 +551,9 @@ sync: func() -> result<_, errno>
 ## `tell`
 ```wit
 /// Return the current offset of a descriptor.
+///
+/// If the descriptor refers to a directory, this function fails with
+/// `errno::spipe`.
 ///
 /// Returns the current offset of the descriptor, relative to the start of the file.
 ///


### PR DESCRIPTION
Document that seek+write and pwrite can write past the end of the file, and that the file is extended with zeros as needed.

This will require extra implementation work on Windows, where writes past the end of files extend with uninitialized bytes, however the upside of the tradeoff is cleaner and more POSIX-compliant behavior for applications, which seems worthwhile here.

Also, document that `seek` and `tell` fail on a directory.

Fixes #13.