### PR TITLE
Remove errno codes that aren't used by filesystem APIs.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -304,25 +304,9 @@ Size: 1, Alignment: 1
 
 ### Enum Cases
 
-- <a href="errno.toobig" name="errno.toobig"></a> [`toobig`](#errno.toobig)
-
-  Argument list too long. This is similar to `E2BIG` in POSIX.
-
 - <a href="errno.access" name="errno.access"></a> [`access`](#errno.access)
 
   Permission denied.
-
-- <a href="errno.addrinuse" name="errno.addrinuse"></a> [`addrinuse`](#errno.addrinuse)
-
-  Address in use.
-
-- <a href="errno.addrnotavail" name="errno.addrnotavail"></a> [`addrnotavail`](#errno.addrnotavail)
-
-  Address not available.
-
-- <a href="errno.afnosupport" name="errno.afnosupport"></a> [`afnosupport`](#errno.afnosupport)
-
-  Address family not supported.
 
 - <a href="errno.again" name="errno.again"></a> [`again`](#errno.again)
 
@@ -336,41 +320,17 @@ Size: 1, Alignment: 1
 
   Bad descriptor.
 
-- <a href="errno.badmsg" name="errno.badmsg"></a> [`badmsg`](#errno.badmsg)
-
-  Bad message.
-
 - <a href="errno.busy" name="errno.busy"></a> [`busy`](#errno.busy)
 
   Device or resource busy.
-
-- <a href="errno.canceled" name="errno.canceled"></a> [`canceled`](#errno.canceled)
-
-  Operation canceled.
 
 - <a href="errno.child" name="errno.child"></a> [`child`](#errno.child)
 
   No child processes.
 
-- <a href="errno.connaborted" name="errno.connaborted"></a> [`connaborted`](#errno.connaborted)
-
-  Connection aborted.
-
-- <a href="errno.connrefused" name="errno.connrefused"></a> [`connrefused`](#errno.connrefused)
-
-  Connection refused.
-
-- <a href="errno.connreset" name="errno.connreset"></a> [`connreset`](#errno.connreset)
-
-  Connection reset.
-
 - <a href="errno.deadlk" name="errno.deadlk"></a> [`deadlk`](#errno.deadlk)
 
   Resource deadlock would occur.
-
-- <a href="errno.destaddrreq" name="errno.destaddrreq"></a> [`destaddrreq`](#errno.destaddrreq)
-
-  Destination address required.
 
 - <a href="errno.dquot" name="errno.dquot"></a> [`dquot`](#errno.dquot)
 
@@ -380,21 +340,9 @@ Size: 1, Alignment: 1
 
   File exists.
 
-- <a href="errno.fault" name="errno.fault"></a> [`fault`](#errno.fault)
-
-  Bad address.
-
 - <a href="errno.fbig" name="errno.fbig"></a> [`fbig`](#errno.fbig)
 
   File too large.
-
-- <a href="errno.hostunreach" name="errno.hostunreach"></a> [`hostunreach`](#errno.hostunreach)
-
-  Host is unreachable.
-
-- <a href="errno.idrm" name="errno.idrm"></a> [`idrm`](#errno.idrm)
-
-  Identifier removed.
 
 - <a href="errno.ilseq" name="errno.ilseq"></a> [`ilseq`](#errno.ilseq)
 
@@ -416,10 +364,6 @@ Size: 1, Alignment: 1
 
   I/O error.
 
-- <a href="errno.isconn" name="errno.isconn"></a> [`isconn`](#errno.isconn)
-
-  Socket is connected.
-
 - <a href="errno.isdir" name="errno.isdir"></a> [`isdir`](#errno.isdir)
 
   Is a directory.
@@ -427,10 +371,6 @@ Size: 1, Alignment: 1
 - <a href="errno.loop" name="errno.loop"></a> [`loop`](#errno.loop)
 
   Too many levels of symbolic links.
-
-- <a href="errno.mfile" name="errno.mfile"></a> [`mfile`](#errno.mfile)
-
-  File descriptor value too large.
 
 - <a href="errno.mlink" name="errno.mlink"></a> [`mlink`](#errno.mlink)
 
@@ -440,33 +380,9 @@ Size: 1, Alignment: 1
 
   Message too large.
 
-- <a href="errno.multihop" name="errno.multihop"></a> [`multihop`](#errno.multihop)
-
-  Multihop attempted.
-
 - <a href="errno.nametoolong" name="errno.nametoolong"></a> [`nametoolong`](#errno.nametoolong)
 
   Filename too long.
-
-- <a href="errno.netdown" name="errno.netdown"></a> [`netdown`](#errno.netdown)
-
-  Network is down.
-
-- <a href="errno.netreset" name="errno.netreset"></a> [`netreset`](#errno.netreset)
-
-  Connection aborted by network.
-
-- <a href="errno.netunreach" name="errno.netunreach"></a> [`netunreach`](#errno.netunreach)
-
-  Network unreachable.
-
-- <a href="errno.nfile" name="errno.nfile"></a> [`nfile`](#errno.nfile)
-
-  Too many files open in system.
-
-- <a href="errno.nobufs" name="errno.nobufs"></a> [`nobufs`](#errno.nobufs)
-
-  No buffer space available.
 
 - <a href="errno.nodev" name="errno.nodev"></a> [`nodev`](#errno.nodev)
 
@@ -476,29 +392,13 @@ Size: 1, Alignment: 1
 
   No such file or directory.
 
-- <a href="errno.noexec" name="errno.noexec"></a> [`noexec`](#errno.noexec)
-
-  Executable file format error.
-
 - <a href="errno.nolck" name="errno.nolck"></a> [`nolck`](#errno.nolck)
 
   No locks available.
 
-- <a href="errno.nolink" name="errno.nolink"></a> [`nolink`](#errno.nolink)
-
-  Link has been severed.
-
 - <a href="errno.nomem" name="errno.nomem"></a> [`nomem`](#errno.nomem)
 
   Not enough space.
-
-- <a href="errno.nomsg" name="errno.nomsg"></a> [`nomsg`](#errno.nomsg)
-
-  No message of the desired type.
-
-- <a href="errno.noprotoopt" name="errno.noprotoopt"></a> [`noprotoopt`](#errno.noprotoopt)
-
-  Protocol not available.
 
 - <a href="errno.nospc" name="errno.nospc"></a> [`nospc`](#errno.nospc)
 
@@ -536,10 +436,6 @@ Size: 1, Alignment: 1
 
   Value too large to be stored in data type.
 
-- <a href="errno.ownerdead" name="errno.ownerdead"></a> [`ownerdead`](#errno.ownerdead)
-
-  Previous owner died.
-
 - <a href="errno.perm" name="errno.perm"></a> [`perm`](#errno.perm)
 
   Operation not permitted.
@@ -548,10 +444,6 @@ Size: 1, Alignment: 1
 
   Broken pipe.
 
-- <a href="errno.range" name="errno.range"></a> [`range`](#errno.range)
-
-  Result too large.
-
 - <a href="errno.rofs" name="errno.rofs"></a> [`rofs`](#errno.rofs)
 
   Read-only file system.
@@ -559,18 +451,6 @@ Size: 1, Alignment: 1
 - <a href="errno.spipe" name="errno.spipe"></a> [`spipe`](#errno.spipe)
 
   Invalid seek.
-
-- <a href="errno.srch" name="errno.srch"></a> [`srch`](#errno.srch)
-
-  No such process.
-
-- <a href="errno.stale" name="errno.stale"></a> [`stale`](#errno.stale)
-
-  Stale file handle.
-
-- <a href="errno.timedout" name="errno.timedout"></a> [`timedout`](#errno.timedout)
-
-  Connection timed out.
 
 - <a href="errno.txtbsy" name="errno.txtbsy"></a> [`txtbsy`](#errno.txtbsy)
 

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -216,52 +216,26 @@ record dir-entry {
 /// API; some are used in higher-level library layers, and others are provided
 /// merely for alignment with POSIX.
 enum errno {
-    /// Argument list too long. This is similar to `E2BIG` in POSIX.
-    toobig,
     /// Permission denied.
     access,
-    /// Address in use.
-    addrinuse,
-    /// Address not available.
-    addrnotavail,
-    /// Address family not supported.
-    afnosupport,
     /// Resource unavailable, or operation would block.
     again,
     /// Connection already in progress.
     already,
     /// Bad descriptor.
     badf,
-    /// Bad message.
-    badmsg,
     /// Device or resource busy.
     busy,
-    /// Operation canceled.
-    canceled,
     /// No child processes.
     child,
-    /// Connection aborted.
-    connaborted,
-    /// Connection refused.
-    connrefused,
-    /// Connection reset.
-    connreset,
     /// Resource deadlock would occur.
     deadlk,
-    /// Destination address required.
-    destaddrreq,
     /// Storage quota exceeded.
     dquot,
     /// File exists.
     exist,
-    /// Bad address.
-    fault,
     /// File too large.
     fbig,
-    /// Host is unreachable.
-    hostunreach,
-    /// Identifier removed.
-    idrm,
     /// Illegal byte sequence.
     ilseq,
     /// Operation in progress.
@@ -272,48 +246,24 @@ enum errno {
     inval,
     /// I/O error.
     io,
-    /// Socket is connected.
-    isconn,
     /// Is a directory.
     isdir,
     /// Too many levels of symbolic links.
     loop,
-    /// File descriptor value too large.
-    mfile,
     /// Too many links.
     mlink,
     /// Message too large.
     msgsize,
-    /// Multihop attempted.
-    multihop,
     /// Filename too long.
     nametoolong,
-    /// Network is down.
-    netdown,
-    /// Connection aborted by network.
-    netreset,
-    /// Network unreachable.
-    netunreach,
-    /// Too many files open in system.
-    nfile,
-    /// No buffer space available.
-    nobufs,
     /// No such device.
     nodev,
     /// No such file or directory.
     noent,
-    /// Executable file format error.
-    noexec,
     /// No locks available.
     nolck,
-    /// Link has been severed.
-    nolink,
     /// Not enough space.
     nomem,
-    /// No message of the desired type.
-    nomsg,
-    /// Protocol not available.
-    noprotoopt,
     /// No space left on device.
     nospc,
     /// Function not supported.
@@ -332,24 +282,14 @@ enum errno {
     nxio,
     /// Value too large to be stored in data type.
     overflow,
-    /// Previous owner died.
-    ownerdead,
     /// Operation not permitted.
     perm,
     /// Broken pipe.
     pipe,
-    /// Result too large.
-    range,
     /// Read-only file system.
     rofs,
     /// Invalid seek.
     spipe,
-    /// No such process.
-    srch,
-    /// Stale file handle.
-    stale,
-    /// Connection timed out.
-    timedout,
     /// Text file busy.
     txtbsy,
     /// Cross-device link.


### PR DESCRIPTION
Instead of WASI having a single errno space, each WASI interface defines its own error types. POSIX compatibility is provided by the libc layer.

Codes used in filesystem APIs but not relevant to WASI:

 - nfile - This may be reported by libc, but wasi-filesystem itself doesn't because it will let the handle mechanism take care of everything.

 - mfile - WASI programs should not be able to observe "the system" having an open-file limit.

 - fault - This is used in POSIX to report invalid pointers, however in WASI that's handled in the bindings layer instead of in individual interfaces.

Codes only used in network APIs (these will be defined in wasi-sockets):

 - afnosupport
 - addrinuse
 - addrnotavail
 - noprotoopt
 - destaddrreq
 - hostunreach
 - isconn
 - connaborted
 - connrefused
 - connreset
 - netdown
 - netreset
 - netunreach
 - timedout
 - multihop
 - nobufs

Codes only used in other non-filesystem APIs:

 - toobig
 - badmsg
 - canceled
 - idrm
 - noexec
 - nolink
 - nomsg
 - ownerdead
 - range
 - srch
 - stale