### PR TITLE
Remove the device and inode numbers from the API.

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -1389,7 +1389,8 @@ to by a descriptor.</p>
 <p>This returns a hash of the last-modification timestamp and file size, and
 may also include the inode number, device number, birth timestamp, and
 other metadata fields that may change when the file is modified or
-replaced.</p>
+replaced. It may also include a secret value chosen by the
+implementation and not otherwise exposed.</p>
 <p>Implementations are encourated to provide the following properties:</p>
 <ul>
 <li>If the file is not modified or replaced, the computed hash value should

--- a/example-world.md
+++ b/example-world.md
@@ -71,21 +71,6 @@ when it does, they are expected to subsume this API.</p>
 <p>An error type returned from a stream operation. Currently this
 doesn't provide any additional information.</p>
 <h5>Record Fields</h5>
-<h4><a name="input_stream"><code>type input-stream</code></a></h4>
-<p><code>u32</code></p>
-<p>An input bytestream. In the future, this will be replaced by handle
-types.
-<p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
-scaffolding until component-model's async features are ready.</p>
-<p><a href="#input_stream"><code>input-stream</code></a>s are <em>non-blocking</em> to the extent practical on underlying
-platforms. I/O operations always return promptly; if fewer bytes are
-promptly available than requested, they return the number of bytes promptly
-available, which could even be zero. To wait for data to be available,
-use the <a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a> function to obtain a <a href="#pollable"><code>pollable</code></a> which
-can be polled for using <code>wasi_poll</code>.</p>
-<p>And at present, it is a <code>u32</code> instead of being an actual handle, until
-the wit-bindgen implementation of handles and resources is ready.</p>
-<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
 <h4><a name="output_stream"><code>type output-stream</code></a></h4>
 <p><code>u32</code></p>
 <p>An output bytestream. In the future, this will be replaced by handle
@@ -98,6 +83,21 @@ always return promptly, after the number of bytes that can be written
 promptly, which could even be zero. To wait for the stream to be ready to
 accept data, the <a href="#subscribe_to_output_stream"><code>subscribe-to-output-stream</code></a> function to obtain a
 <a href="#pollable"><code>pollable</code></a> which can be polled for using <code>wasi_poll</code>.</p>
+<p>And at present, it is a <code>u32</code> instead of being an actual handle, until
+the wit-bindgen implementation of handles and resources is ready.</p>
+<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
+<h4><a name="input_stream"><code>type input-stream</code></a></h4>
+<p><code>u32</code></p>
+<p>An input bytestream. In the future, this will be replaced by handle
+types.
+<p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
+scaffolding until component-model's async features are ready.</p>
+<p><a href="#input_stream"><code>input-stream</code></a>s are <em>non-blocking</em> to the extent practical on underlying
+platforms. I/O operations always return promptly; if fewer bytes are
+promptly available than requested, they return the number of bytes promptly
+available, which could even be zero. To wait for data to be available,
+use the <a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a> function to obtain a <a href="#pollable"><code>pollable</code></a> which
+can be polled for using <code>wasi_poll</code>.</p>
 <p>And at present, it is a <code>u32</code> instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.</p>
 <p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
@@ -377,108 +377,7 @@ underlying filesystem, the function fails with <a href="#error_code.not_permitte
 #### <a name="datetime">`type datetime`</a>
 [`datetime`](#datetime)
 <p>
-#### <a name="filesize">`type filesize`</a>
-`u64`
-<p>File size or length of a region within a file.
-<h4><a name="descriptor_type"><code>enum descriptor-type</code></a></h4>
-<p>The type of a filesystem object referenced by a descriptor.</p>
-<p>Note: This was called <code>filetype</code> in earlier versions of WASI.</p>
-<h5>Enum Cases</h5>
-<ul>
-<li>
-<p><a name="descriptor_type.unknown"><code>unknown</code></a></p>
-<p>The type of the descriptor or file is unknown or is different from
-any of the other types specified.
-</li>
-<li>
-<p><a name="descriptor_type.block_device"><code>block-device</code></a></p>
-<p>The descriptor refers to a block device inode.
-</li>
-<li>
-<p><a name="descriptor_type.character_device"><code>character-device</code></a></p>
-<p>The descriptor refers to a character device inode.
-</li>
-<li>
-<p><a name="descriptor_type.directory"><code>directory</code></a></p>
-<p>The descriptor refers to a directory inode.
-</li>
-<li>
-<p><a name="descriptor_type.fifo"><code>fifo</code></a></p>
-<p>The descriptor refers to a named pipe.
-</li>
-<li>
-<p><a name="descriptor_type.symbolic_link"><code>symbolic-link</code></a></p>
-<p>The file refers to a symbolic link inode.
-</li>
-<li>
-<p><a name="descriptor_type.regular_file"><code>regular-file</code></a></p>
-<p>The descriptor refers to a regular file inode.
-</li>
-<li>
-<p><a name="descriptor_type.socket"><code>socket</code></a></p>
-<p>The descriptor refers to a socket.
-</li>
-</ul>
-<h4><a name="descriptor_flags"><code>flags descriptor-flags</code></a></h4>
-<p>Descriptor flags.</p>
-<p>Note: This was called <code>fdflags</code> in earlier versions of WASI.</p>
-<h5>Flags members</h5>
-<ul>
-<li>
-<p><a name="descriptor_flags.read"><a href="#read"><code>read</code></a></a>: </p>
-<p>Read mode: Data can be read.
-</li>
-<li>
-<p><a name="descriptor_flags.write"><a href="#write"><code>write</code></a></a>: </p>
-<p>Write mode: Data can be written to.
-</li>
-<li>
-<p><a name="descriptor_flags.non_blocking"><code>non-blocking</code></a>: </p>
-<p>Requests non-blocking operation.
-<p>When this flag is enabled, functions may return immediately with an
-<a href="#error_code.would_block"><code>error-code::would-block</code></a> error code in situations where they would
-otherwise block. However, this non-blocking behavior is not
-required. Implementations are permitted to ignore this flag and
-block. This is similar to <code>O_NONBLOCK</code> in POSIX.</p>
-</li>
-<li>
-<p><a name="descriptor_flags.file_integrity_sync"><code>file-integrity-sync</code></a>: </p>
-<p>Request that writes be performed according to synchronized I/O file
-integrity completion. The data stored in the file and the file's
-metadata are synchronized. This is similar to `O_SYNC` in POSIX.
-<p>The precise semantics of this operation have not yet been defined for
-WASI. At this time, it should be interpreted as a request, and not a
-requirement.</p>
-</li>
-<li>
-<p><a name="descriptor_flags.data_integrity_sync"><code>data-integrity-sync</code></a>: </p>
-<p>Request that writes be performed according to synchronized I/O data
-integrity completion. Only the data stored in the file is
-synchronized. This is similar to `O_DSYNC` in POSIX.
-<p>The precise semantics of this operation have not yet been defined for
-WASI. At this time, it should be interpreted as a request, and not a
-requirement.</p>
-</li>
-<li>
-<p><a name="descriptor_flags.requested_write_sync"><code>requested-write-sync</code></a>: </p>
-<p>Requests that reads be performed at the same level of integrety
-requested for writes. This is similar to `O_RSYNC` in POSIX.
-<p>The precise semantics of this operation have not yet been defined for
-WASI. At this time, it should be interpreted as a request, and not a
-requirement.</p>
-</li>
-<li>
-<p><a name="descriptor_flags.mutate_directory"><code>mutate-directory</code></a>: </p>
-<p>Mutating directories mode: Directory contents may be mutated.
-<p>When this flag is unset on a descriptor, operations using the
-descriptor which would create, rename, delete, modify the data or
-metadata of filesystem objects, or obtain another handle which
-would permit any of those, shall fail with <a href="#error_code.read_only"><code>error-code::read-only</code></a> if
-they would otherwise succeed.</p>
-<p>This may only be set on directories.</p>
-</li>
-</ul>
-<h4><a name="path_flags"><code>flags path-flags</code></a></h4>
+#### <a name="path_flags">`flags path-flags`</a>
 <p>Flags determining the method of how paths are resolved.</p>
 <h5>Flags members</h5>
 <ul>
@@ -528,84 +427,26 @@ filesystem.
 filesystem. This does not apply to directories.
 </li>
 </ul>
-<h4><a name="access_type"><code>variant access-type</code></a></h4>
-<p>Access type used by <a href="#access_at"><code>access-at</code></a>.</p>
-<h5>Variant Cases</h5>
+<h4><a name="metadata_hash_value"><code>record metadata-hash-value</code></a></h4>
+<p>A 128-bit hash value, split into parts because wasm doesn't have a
+128-bit integer type.</p>
+<h5>Record Fields</h5>
 <ul>
 <li>
-<p><a name="access_type.access"><code>access</code></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></p>
-<p>Test for readability, writeability, or executability.
+<p><a name="metadata_hash_value.lower"><code>lower</code></a>: <code>u64</code></p>
+<p>64 bits of a 128-bit hash value.
 </li>
 <li>
-<p><a name="access_type.exists"><code>exists</code></a></p>
-<p>Test whether the path exists.
+<p><a name="metadata_hash_value.upper"><code>upper</code></a>: <code>u64</code></p>
+<p>Another 64 bits of a 128-bit hash value.
 </li>
 </ul>
 <h4><a name="link_count"><code>type link-count</code></a></h4>
 <p><code>u64</code></p>
 <p>Number of hard links to an inode.
-<h4><a name="descriptor_stat"><code>record descriptor-stat</code></a></h4>
-<p>File attributes.</p>
-<p>Note: This was called <code>filestat</code> in earlier versions of WASI.</p>
-<h5>Record Fields</h5>
-<ul>
-<li>
-<p><a name="descriptor_stat.type"><code>type</code></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
-<p>File type.
-</li>
-<li>
-<p><a name="descriptor_stat.link_count"><a href="#link_count"><code>link-count</code></a></a>: <a href="#link_count"><a href="#link_count"><code>link-count</code></a></a></p>
-<p>Number of hard links to the file.
-</li>
-<li>
-<p><a name="descriptor_stat.size"><code>size</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></p>
-<p>For regular files, the file size in bytes. For symbolic links, the
-length in bytes of the pathname contained in the symbolic link.
-</li>
-<li>
-<p><a name="descriptor_stat.data_access_timestamp"><code>data-access-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
-<p>Last data access timestamp.
-</li>
-<li>
-<p><a name="descriptor_stat.data_modification_timestamp"><code>data-modification-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
-<p>Last data modification timestamp.
-</li>
-<li>
-<p><a name="descriptor_stat.status_change_timestamp"><code>status-change-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
-<p>Last file status change timestamp.
-</li>
-</ul>
-<h4><a name="new_timestamp"><code>variant new-timestamp</code></a></h4>
-<p>When setting a timestamp, this gives the value to set it to.</p>
-<h5>Variant Cases</h5>
-<ul>
-<li>
-<p><a name="new_timestamp.no_change"><code>no-change</code></a></p>
-<p>Leave the timestamp set to its previous value.
-</li>
-<li>
-<p><a name="new_timestamp.now"><a href="#now"><code>now</code></a></a></p>
-<p>Set the timestamp to the current time of the system clock associated
-with the filesystem.
-</li>
-<li>
-<p><a name="new_timestamp.timestamp"><code>timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
-<p>Set the timestamp to the given value.
-</li>
-</ul>
-<h4><a name="directory_entry"><code>record directory-entry</code></a></h4>
-<p>A directory entry.</p>
-<h5>Record Fields</h5>
-<ul>
-<li>
-<p><a name="directory_entry.type"><code>type</code></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
-<p>The type of the file referred to by this directory entry.
-</li>
-<li>
-<p><a name="directory_entry.name"><code>name</code></a>: <code>string</code></p>
-<p>The name of the object.
-</li>
-</ul>
+<h4><a name="filesize"><code>type filesize</code></a></h4>
+<p><code>u64</code></p>
+<p>File size or length of a region within a file.
 <h4><a name="error_code"><code>enum error-code</code></a></h4>
 <p>Error codes returned by functions, similar to <code>errno</code> in POSIX.
 Not all of these error codes are returned by the functions provided by this
@@ -762,6 +603,176 @@ merely for alignment with POSIX.</p>
 <p>Cross-device link, similar to `EXDEV` in POSIX.
 </li>
 </ul>
+<h4><a name="directory_entry_stream"><code>type directory-entry-stream</code></a></h4>
+<p><code>u32</code></p>
+<p>A stream of directory entries.
+<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Streams">represents a stream of <code>dir-entry</code></a>.</p>
+<h4><a name="descriptor_type"><code>enum descriptor-type</code></a></h4>
+<p>The type of a filesystem object referenced by a descriptor.</p>
+<p>Note: This was called <code>filetype</code> in earlier versions of WASI.</p>
+<h5>Enum Cases</h5>
+<ul>
+<li>
+<p><a name="descriptor_type.unknown"><code>unknown</code></a></p>
+<p>The type of the descriptor or file is unknown or is different from
+any of the other types specified.
+</li>
+<li>
+<p><a name="descriptor_type.block_device"><code>block-device</code></a></p>
+<p>The descriptor refers to a block device inode.
+</li>
+<li>
+<p><a name="descriptor_type.character_device"><code>character-device</code></a></p>
+<p>The descriptor refers to a character device inode.
+</li>
+<li>
+<p><a name="descriptor_type.directory"><code>directory</code></a></p>
+<p>The descriptor refers to a directory inode.
+</li>
+<li>
+<p><a name="descriptor_type.fifo"><code>fifo</code></a></p>
+<p>The descriptor refers to a named pipe.
+</li>
+<li>
+<p><a name="descriptor_type.symbolic_link"><code>symbolic-link</code></a></p>
+<p>The file refers to a symbolic link inode.
+</li>
+<li>
+<p><a name="descriptor_type.regular_file"><code>regular-file</code></a></p>
+<p>The descriptor refers to a regular file inode.
+</li>
+<li>
+<p><a name="descriptor_type.socket"><code>socket</code></a></p>
+<p>The descriptor refers to a socket.
+</li>
+</ul>
+<h4><a name="directory_entry"><code>record directory-entry</code></a></h4>
+<p>A directory entry.</p>
+<h5>Record Fields</h5>
+<ul>
+<li>
+<p><a name="directory_entry.type"><code>type</code></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
+<p>The type of the file referred to by this directory entry.
+</li>
+<li>
+<p><a name="directory_entry.name"><code>name</code></a>: <code>string</code></p>
+<p>The name of the object.
+</li>
+</ul>
+<h4><a name="descriptor_flags"><code>flags descriptor-flags</code></a></h4>
+<p>Descriptor flags.</p>
+<p>Note: This was called <code>fdflags</code> in earlier versions of WASI.</p>
+<h5>Flags members</h5>
+<ul>
+<li>
+<p><a name="descriptor_flags.read"><a href="#read"><code>read</code></a></a>: </p>
+<p>Read mode: Data can be read.
+</li>
+<li>
+<p><a name="descriptor_flags.write"><a href="#write"><code>write</code></a></a>: </p>
+<p>Write mode: Data can be written to.
+</li>
+<li>
+<p><a name="descriptor_flags.non_blocking"><code>non-blocking</code></a>: </p>
+<p>Requests non-blocking operation.
+<p>When this flag is enabled, functions may return immediately with an
+<a href="#error_code.would_block"><code>error-code::would-block</code></a> error code in situations where they would
+otherwise block. However, this non-blocking behavior is not
+required. Implementations are permitted to ignore this flag and
+block. This is similar to <code>O_NONBLOCK</code> in POSIX.</p>
+</li>
+<li>
+<p><a name="descriptor_flags.file_integrity_sync"><code>file-integrity-sync</code></a>: </p>
+<p>Request that writes be performed according to synchronized I/O file
+integrity completion. The data stored in the file and the file's
+metadata are synchronized. This is similar to `O_SYNC` in POSIX.
+<p>The precise semantics of this operation have not yet been defined for
+WASI. At this time, it should be interpreted as a request, and not a
+requirement.</p>
+</li>
+<li>
+<p><a name="descriptor_flags.data_integrity_sync"><code>data-integrity-sync</code></a>: </p>
+<p>Request that writes be performed according to synchronized I/O data
+integrity completion. Only the data stored in the file is
+synchronized. This is similar to `O_DSYNC` in POSIX.
+<p>The precise semantics of this operation have not yet been defined for
+WASI. At this time, it should be interpreted as a request, and not a
+requirement.</p>
+</li>
+<li>
+<p><a name="descriptor_flags.requested_write_sync"><code>requested-write-sync</code></a>: </p>
+<p>Requests that reads be performed at the same level of integrety
+requested for writes. This is similar to `O_RSYNC` in POSIX.
+<p>The precise semantics of this operation have not yet been defined for
+WASI. At this time, it should be interpreted as a request, and not a
+requirement.</p>
+</li>
+<li>
+<p><a name="descriptor_flags.mutate_directory"><code>mutate-directory</code></a>: </p>
+<p>Mutating directories mode: Directory contents may be mutated.
+<p>When this flag is unset on a descriptor, operations using the
+descriptor which would create, rename, delete, modify the data or
+metadata of filesystem objects, or obtain another handle which
+would permit any of those, shall fail with <a href="#error_code.read_only"><code>error-code::read-only</code></a> if
+they would otherwise succeed.</p>
+<p>This may only be set on directories.</p>
+</li>
+</ul>
+<h4><a name="descriptor"><code>type descriptor</code></a></h4>
+<p><code>u32</code></p>
+<p>A descriptor is a reference to a filesystem object, which may be a file,
+directory, named pipe, special file, or other object on which filesystem
+calls may be made.
+<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
+<h4><a name="new_timestamp"><code>variant new-timestamp</code></a></h4>
+<p>When setting a timestamp, this gives the value to set it to.</p>
+<h5>Variant Cases</h5>
+<ul>
+<li>
+<p><a name="new_timestamp.no_change"><code>no-change</code></a></p>
+<p>Leave the timestamp set to its previous value.
+</li>
+<li>
+<p><a name="new_timestamp.now"><a href="#now"><code>now</code></a></a></p>
+<p>Set the timestamp to the current time of the system clock associated
+with the filesystem.
+</li>
+<li>
+<p><a name="new_timestamp.timestamp"><code>timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Set the timestamp to the given value.
+</li>
+</ul>
+<h4><a name="descriptor_stat"><code>record descriptor-stat</code></a></h4>
+<p>File attributes.</p>
+<p>Note: This was called <code>filestat</code> in earlier versions of WASI.</p>
+<h5>Record Fields</h5>
+<ul>
+<li>
+<p><a name="descriptor_stat.type"><code>type</code></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
+<p>File type.
+</li>
+<li>
+<p><a name="descriptor_stat.link_count"><a href="#link_count"><code>link-count</code></a></a>: <a href="#link_count"><a href="#link_count"><code>link-count</code></a></a></p>
+<p>Number of hard links to the file.
+</li>
+<li>
+<p><a name="descriptor_stat.size"><code>size</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></p>
+<p>For regular files, the file size in bytes. For symbolic links, the
+length in bytes of the pathname contained in the symbolic link.
+</li>
+<li>
+<p><a name="descriptor_stat.data_access_timestamp"><code>data-access-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Last data access timestamp.
+</li>
+<li>
+<p><a name="descriptor_stat.data_modification_timestamp"><code>data-modification-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Last data modification timestamp.
+</li>
+<li>
+<p><a name="descriptor_stat.status_change_timestamp"><code>status-change-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Last file status change timestamp.
+</li>
+</ul>
 <h4><a name="advice"><code>enum advice</code></a></h4>
 <p>File or memory access pattern advisory information.</p>
 <h5>Enum Cases</h5>
@@ -797,16 +808,19 @@ in the near future.
 not reuse it thereafter.
 </li>
 </ul>
-<h4><a name="descriptor"><code>type descriptor</code></a></h4>
-<p><code>u32</code></p>
-<p>A descriptor is a reference to a filesystem object, which may be a file,
-directory, named pipe, special file, or other object on which filesystem
-calls may be made.
-<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources">represents a resource</a>.</p>
-<h4><a name="directory_entry_stream"><code>type directory-entry-stream</code></a></h4>
-<p><code>u32</code></p>
-<p>A stream of directory entries.
-<p>This <a href="https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Streams">represents a stream of <code>dir-entry</code></a>.</p>
+<h4><a name="access_type"><code>variant access-type</code></a></h4>
+<p>Access type used by <a href="#access_at"><code>access-at</code></a>.</p>
+<h5>Variant Cases</h5>
+<ul>
+<li>
+<p><a name="access_type.access"><code>access</code></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></p>
+<p>Test for readability, writeability, or executability.
+</li>
+<li>
+<p><a name="access_type.exists"><code>exists</code></a></p>
+<p>Test whether the path exists.
+</li>
+</ul>
 <hr />
 <h3>Functions</h3>
 <h4><a name="read_via_stream"><code>read-via-stream: func</code></a></h4>
@@ -1403,7 +1417,7 @@ computed hash.</li>
 <p>However, none of these is required.</p>
 <h5>Return values</h5>
 <ul>
-<li><a name="metadata_hash.0"></a> result&lt;(<code>u64</code>, <code>u64</code>), <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="metadata_hash.0"></a> result&lt;<a href="#metadata_hash_value"><a href="#metadata_hash_value"><code>metadata-hash-value</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h4><a name="metadata_hash_at"><code>metadata-hash-at: func</code></a></h4>
 <p>Return a hash of the metadata associated with a filesystem object referred
@@ -1416,7 +1430,7 @@ to by a directory descriptor and a relative path.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="metadata_hash_at.0"></a> result&lt;(<code>u64</code>, <code>u64</code>), <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="metadata_hash_at.0"></a> result&lt;<a href="#metadata_hash_value"><a href="#metadata_hash_value"><code>metadata-hash-value</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:filesystem_preopens">Import interface wasi:filesystem/preopens</a></h2>
 <hr />

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -801,7 +801,8 @@ interface types {
     /// This returns a hash of the last-modification timestamp and file size, and
     /// may also include the inode number, device number, birth timestamp, and
     /// other metadata fields that may change when the file is modified or
-    /// replaced.
+    /// replaced. It may also include a secret value chosen by the
+    /// implementation and not otherwise exposed.
     ///
     /// Implementations are encourated to provide the following properties:
     ///

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -292,6 +292,15 @@ interface types {
     /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
     type descriptor = u32
 
+    /// A 128-bit hash value, split into parts because wasm doesn't have a
+    /// 128-bit integer type.
+    record metadata-hash-value {
+       /// 64 bits of a 128-bit hash value.
+       lower: u64,
+       /// Another 64 bits of a 128-bit hash value.
+       upper: u64,
+    }
+
     /// Return a stream for reading from a file, if available.
     ///
     /// May fail with an error-code describing why the file cannot be read.
@@ -814,7 +823,7 @@ interface types {
     ///    computed hash.
     ///
     /// However, none of these is required.
-    metadata-hash: func() -> result<tuple<u64, u64>, error-code>
+    metadata-hash: func() -> result<metadata-hash-value, error-code>
 
     /// Return a hash of the metadata associated with a filesystem object referred
     /// to by a directory descriptor and a relative path.
@@ -825,5 +834,5 @@ interface types {
         path-flags: path-flags,
         /// The relative path of the file or directory to inspect.
         path: string,
-    ) -> result<tuple<u64, u64>, error-code>
+    ) -> result<metadata-hash-value, error-code>
 }

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -102,10 +102,6 @@ interface types {
     ///
     /// Note: This was called `filestat` in earlier versions of WASI.
     record descriptor-stat {
-        /// Device ID of device containing the file.
-        device: device,
-        /// File serial number.
-        inode: inode,
         /// File type.
         %type: descriptor-type,
         /// Number of hard links to the file.
@@ -166,14 +162,6 @@ interface types {
     /// Number of hard links to an inode.
     type link-count = u64
 
-    /// Identifier for a device containing a file system. Can be used in
-    /// combination with `inode` to uniquely identify a file or directory in
-    /// the filesystem.
-    type device = u64
-
-    /// Filesystem object serial number that is unique within its file system.
-    type inode = u64
-
     /// When setting a timestamp, this gives the value to set it to.
     variant new-timestamp {
         /// Leave the timestamp set to its previous value.
@@ -187,14 +175,6 @@ interface types {
 
     /// A directory entry.
     record directory-entry {
-        /// The serial number of the object referred to by this directory entry.
-        /// May be none if the inode value is not known.
-        ///
-        /// When this is none, libc implementations might do an extra `stat-at`
-        /// call to retrieve the inode number to fill their `d_ino` fields, so
-        /// implementations which can set this to a non-none value should do so.
-        inode: option<inode>,
-
         /// The type of the file referred to by this directory entry.
         %type: descriptor-type,
 
@@ -485,14 +465,20 @@ interface types {
 
     /// Return the attributes of an open file or directory.
     ///
-    /// Note: This is similar to `fstat` in POSIX.
+    /// Note: This is similar to `fstat` in POSIX, except that it does not return
+    /// device and inode information. For testing whether two descriptors refer to
+    /// the same underlying filesystem object, use `is-same-object`. To obtain
+    /// additional data that can be used do determine whether a file has been
+    /// modified, use `metadata-hash`.
     ///
     /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
     stat: func(this: descriptor) -> result<descriptor-stat, error-code>
 
     /// Return the attributes of a file or directory.
     ///
-    /// Note: This is similar to `fstatat` in POSIX.
+    /// Note: This is similar to `fstatat` in POSIX, except that it does not
+    /// return device and inode information. See the `stat` description for a
+    /// discussion of alternatives.
     ///
     /// Note: This was called `path_filestat_get` in earlier versions of WASI.
     stat-at: func(
@@ -800,4 +786,43 @@ interface types {
     /// Dispose of the specified `directory-entry-stream`, after which it may no longer
     /// be used.
     drop-directory-entry-stream: func(this: directory-entry-stream)
+
+    /// Test whether two descriptors refer to the same filesystem object.
+    ///
+    /// In POSIX, this corresponds to testing whether the two descriptors have the
+    /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
+    /// wasi-filesystem does not expose device and inode numbers, so this function
+    /// may be used instead.
+    is-same-object: func(other: descriptor) -> bool
+
+    /// Return a hash of the metadata associated with a filesystem object referred
+    /// to by a descriptor.
+    ///
+    /// This returns a hash of the last-modification timestamp and file size, and
+    /// may also include the inode number, device number, birth timestamp, and
+    /// other metadata fields that may change when the file is modified or
+    /// replaced.
+    ///
+    /// Implementations are encourated to provide the following properties:
+    ///
+    ///  - If the file is not modified or replaced, the computed hash value should
+    ///    usually not change.
+    ///  - If the object is modified or replaced, the computed hash value should
+    ///    usually change.
+    ///  - The inputs to the hash should not be easily computable from the
+    ///    computed hash.
+    ///
+    /// However, none of these is required.
+    metadata-hash: func() -> result<tuple<u64, u64>, error-code>
+
+    /// Return a hash of the metadata associated with a filesystem object referred
+    /// to by a directory descriptor and a relative path.
+    ///
+    /// This performs the same hash computation as `metadata-hash`.
+    metadata-hash-at: func(
+        /// Flags determining the method of how the path is resolved.
+        path-flags: path-flags,
+        /// The relative path of the file or directory to inspect.
+        path: string,
+    ) -> result<tuple<u64, u64>, error-code>
 }


### PR DESCRIPTION
As discussed [here], remove the fields which correspond to `st_dev`, `st_ino`, and `d_ino` in POSIX from the stat and directory entry structs.

 - Device numbers assume the existence of a global device number space, which creates implicit relationships between otherwise unrelated components.

 - Not all filesystem implementations have these numbers. And some that do have these numbers require extra implementation cost to retrieve them.

 - These numbers leak potentially sensitive or identifying information from the underlying filesystem implementation.

In their place, provide two functions, `is-same-file` and `is-same-mountpoint`, for explicitly testing whether two handles are the same file or are on the same mountpoint, respectively. This doesn't cover all possible use cases for device and inode numbers, but we can add more functions as need arises.

[here]: https://github.com/WebAssembly/wasi-filesystem/issues/65#issuecomment-1353986502