### PR TITLE
Remove the `size` type.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -1,11 +1,5 @@
 # Types
 
-## <a href="#size" name="size"></a> `size`: `u32`
-
-  Size of a range of bytes in memory.
-
-Size: 4, Alignment: 4
-
 ## <a href="#filesize" name="filesize"></a> `filesize`: `u64`
 
   Non-negative file size or length of a region within a file.
@@ -532,7 +526,7 @@ Size: 16, Alignment: 8
 
 - <a href="#descriptor_fadvise.self" name="descriptor_fadvise.self"></a> `self`: handle<descriptor>
 - <a href="#descriptor_fadvise.offset" name="descriptor_fadvise.offset"></a> `offset`: [`filesize`](#filesize)
-- <a href="#descriptor_fadvise.len" name="descriptor_fadvise.len"></a> `len`: [`size`](#size)
+- <a href="#descriptor_fadvise.len" name="descriptor_fadvise.len"></a> `len`: [`filesize`](#filesize)
 - <a href="#descriptor_fadvise.advice" name="descriptor_fadvise.advice"></a> `advice`: [`advice`](#advice)
 ##### Results
 
@@ -651,7 +645,7 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#descriptor_pread.self" name="descriptor_pread.self"></a> `self`: handle<descriptor>
-- <a href="#descriptor_pread.len" name="descriptor_pread.len"></a> `len`: [`size`](#size)
+- <a href="#descriptor_pread.len" name="descriptor_pread.len"></a> `len`: [`filesize`](#filesize)
 - <a href="#descriptor_pread.offset" name="descriptor_pread.offset"></a> `offset`: [`filesize`](#filesize)
 ##### Results
 
@@ -675,7 +669,7 @@ Size: 16, Alignment: 8
 - <a href="#descriptor_pwrite.offset" name="descriptor_pwrite.offset"></a> `offset`: [`filesize`](#filesize)
 ##### Results
 
-- future<result<[`size`](#size), [`errno`](#errno)>>
+- future<result<[`filesize`](#filesize), [`errno`](#errno)>>
 
 ----
 

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -11,12 +11,6 @@ Paths are passed as interface-type `string`s, meaning they must consist of
 a sequence of Unicode Scalar Values (USVs). Some filesystems may contain paths
 which are not accessible by this API.
 
-## `size`
-```wit
-/// Size of a range of bytes in memory.
-type size = u32
-```
-
 ## `filesize`
 ```wit
 /// Non-negative file size or length of a region within a file.
@@ -348,7 +342,7 @@ fadvise: func(
     /// The offset within the file to which the advisory applies.
     offset: filesize,
     /// The length of the region to which the advisory applies.
-    len: size,
+    len: filesize,
     /// The advice.
     advice: advice
 ) -> result<_, errno>
@@ -429,7 +423,7 @@ set-times: func(
 /// Note: This is similar to `pread` in POSIX.
 pread: func(
     /// The maximim number of bytes to read.
-    len: size,
+    len: filesize,
     /// The offset within the file at which to read.
     offset: filesize,
 ) -> stream<u8, errno>
@@ -449,7 +443,7 @@ pwrite: func(
     buf: stream<u8>,
     /// The offset within the file at which to write.
     offset: filesize,
-) -> future<result<size, errno>>
+) -> future<result<filesize, errno>>
 ```
 
 ## `readdir`


### PR DESCRIPTION
Use `filesize` in `fadvise`, `pread`, and `pwrite`, instead of `size`. This makes the API independent of wasm32 vs. wasm64 or even linear memory vs. other options.

This does mean that a wasm32 program can request a `pread` of more bytes than it can possibly recieve, but it'll just get a short read.