### PR TITLE
Document that `fsync` on a readonly file succeeds.

### DIFF
--- a/wasi-filesystem.abi.md
+++ b/wasi-filesystem.abi.md
@@ -545,6 +545,9 @@ Size: 16, Alignment: 8
   Synchronize the data of a file to disk.
   
   Note: This is similar to `fdatasync` in POSIX.
+  
+  This function succeeds with no effect if the file descriptor is not
+  opened for writing.
 ##### Params
 
 - <a href="#descriptor_datasync.self" name="descriptor_datasync.self"></a> `self`: handle<descriptor>
@@ -724,6 +727,9 @@ Size: 16, Alignment: 8
   Synchronize the data and metadata of a file to disk.
   
   Note: This is similar to `fsync` in POSIX.
+  
+  This function succeeds with no effect if the file descriptor is not
+  opened for writing.
 ##### Params
 
 - <a href="#descriptor_sync.self" name="descriptor_sync.self"></a> `self`: handle<descriptor>

--- a/wasi-filesystem.wit.md
+++ b/wasi-filesystem.wit.md
@@ -359,6 +359,9 @@ fadvise: func(
 /// Synchronize the data of a file to disk.
 ///
 /// Note: This is similar to `fdatasync` in POSIX.
+///
+/// This function succeeds with no effect if the file descriptor is not
+/// opened for writing.
 datasync: func() -> result<_, errno>
 ```
 
@@ -487,6 +490,9 @@ seek: func(
 /// Synchronize the data and metadata of a file to disk.
 ///
 /// Note: This is similar to `fsync` in POSIX.
+///
+/// This function succeeds with no effect if the file descriptor is not
+/// opened for writing.
 sync: func() -> result<_, errno>
 ```
 


### PR DESCRIPTION
On POSIX platforms, `fsync` on a readonly file succeeds. On Windows, `FlushFileBuffers` fails on a readonly file, but implementations can be made to handle the error.