### PR TITLE
Document that `fsync` on a readonly file succeeds.

### DIFF
--- a/wasi-filesystem.html
+++ b/wasi-filesystem.html
@@ -469,6 +469,8 @@ Bit: 0</p>
 <hr />
 <h4><a href="#datasync" name="datasync"></a> <a href="#datasync"><code>datasync</code></a></h4>
 <p>Synchronize the data of a file to disk.</p>
+<p>This function succeeds with no effect if the file descriptor is not
+opened for writing.</p>
 <p>Note: This is similar to <code>fdatasync</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
@@ -599,6 +601,8 @@ directory.</p>
 <hr />
 <h4><a href="#sync" name="sync"></a> <a href="#sync"><code>sync</code></a></h4>
 <p>Synchronize the data and metadata of a file to disk.</p>
+<p>This function succeeds with no effect if the file descriptor is not
+opened for writing.</p>
 <p>Note: This is similar to <code>fsync</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>

--- a/wasi-filesystem.md
+++ b/wasi-filesystem.md
@@ -523,6 +523,9 @@ This is similar to `posix_fadvise` in POSIX.
 
 Synchronize the data of a file to disk.
 
+This function succeeds with no effect if the file descriptor is not
+opened for writing.
+
 Note: This is similar to `fdatasync` in POSIX.
 ##### Params
 
@@ -676,6 +679,9 @@ directory.
 #### <a href="#sync" name="sync"></a> `sync` 
 
 Synchronize the data and metadata of a file to disk.
+
+This function succeeds with no effect if the file descriptor is not
+opened for writing.
 
 Note: This is similar to `fsync` in POSIX.
 ##### Params

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -344,6 +344,9 @@ fadvise: func(
 ```wit
 /// Synchronize the data of a file to disk.
 ///
+/// This function succeeds with no effect if the file descriptor is not
+/// opened for writing.
+///
 /// Note: This is similar to `fdatasync` in POSIX.
 datasync: func(this: descriptor) -> result<_, errno>
 ```
@@ -455,6 +458,9 @@ readdir: func(this: descriptor) -> stream<dir-entry-stream, errno>
 ## `sync`
 ```wit
 /// Synchronize the data and metadata of a file to disk.
+///
+/// This function succeeds with no effect if the file descriptor is not
+/// opened for writing.
 ///
 /// Note: This is similar to `fsync` in POSIX.
 sync: func(this: descriptor) -> result<_, errno>


### PR DESCRIPTION
On POSIX platforms, `fsync` on a readonly file succeeds. On Windows, `FlushFileBuffers` fails on a readonly file, but implementations can be made to handle the error.