### PR TITLE
Add support for readonly directories.

### DIFF
--- a/wasi-filesystem.html
+++ b/wasi-filesystem.html
@@ -403,6 +403,17 @@ WASI. At this time, it should be interpreted as a request, and not a
 requirement.
 Bit: 5</p>
 </li>
+<li>
+<p><a href="descriptor_flags.mutate_directory" name="descriptor_flags.mutate_directory"></a> <a href="#descriptor_flags.mutate_directory"><code>mutate-directory</code></a>: </p>
+<p>Mutating directories mode: Directory contents may be mutated.</p>
+<p>When this flag is unset on a descriptor, operations using the
+descriptor which would create, rename, delete, modify the data or
+metadata of filesystem objects, or obtain another handle which
+would permit any of those, shall fail with <a href="#errno.rofs"><code>errno::rofs</code></a> if
+they would otherwise succeed.</p>
+<p>This may only be set on directories.
+Bit: 6</p>
+</li>
 </ul>
 <h2><a href="#descriptor" name="descriptor"></a> <a href="#descriptor"><code>descriptor</code></a>: <code>u32</code></h2>
 <p>A descriptor is a reference to a filesystem object, which may be a file,
@@ -513,7 +524,8 @@ from <code>fdstat_get</code> in earlier versions of WASI.</p>
 </ul>
 <hr />
 <h4><a href="#set_flags" name="set_flags"></a> <a href="#set_flags"><code>set-flags</code></a></h4>
-<p>Set flags associated with a descriptor.</p>
+<p>Set status flags associated with a descriptor.</p>
+<p>This function may only change the <code>append</code> and <code>nonblock</code> flags.</p>
 <p>Note: This is similar to <code>fcntl(fd, F_SETFL, flags)</code> in POSIX.</p>
 <p>Note: This was called <code>fd_fdstat_set_flags</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
@@ -694,6 +706,13 @@ descriptor not currently open/ it is randomized to prevent applications
 from depending on making assumptions about indexes, since this is
 error-prone in multi-threaded contexts. The returned descriptor is
 guaranteed to be less than 2**31.</p>
+<p>If <a href="#flags"><code>flags</code></a> contains <a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a>, and the base
+descriptor doesn't have <a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a> set,
+<a href="#open_at"><code>open-at</code></a> fails with <a href="#errno.rofs"><code>errno::rofs</code></a>.</p>
+<p>If <a href="#flags"><code>flags</code></a> contains <code>write</code> or <code>append</code>, or <a href="#o_flags"><code>o-flags</code></a> contains <code>trunc</code>
+or <code>create</code>, and the base descriptor doesn't have
+<a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a> set, <a href="#open_at"><code>open-at</code></a> fails with
+<a href="#errno.rofs"><code>errno::rofs</code></a>.</p>
 <p>Note: This is similar to <code>openat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>

--- a/wasi-filesystem.md
+++ b/wasi-filesystem.md
@@ -445,6 +445,19 @@ Size: 1, Alignment: 1
   requirement.
   Bit: 5
 
+- <a href="descriptor_flags.mutate_directory" name="descriptor_flags.mutate_directory"></a> [`mutate-directory`](#descriptor_flags.mutate_directory): 
+  
+  Mutating directories mode: Directory contents may be mutated.
+  
+  When this flag is unset on a descriptor, operations using the
+  descriptor which would create, rename, delete, modify the data or
+  metadata of filesystem objects, or obtain another handle which
+  would permit any of those, shall fail with `errno::rofs` if
+  they would otherwise succeed.
+  
+  This may only be set on directories.
+  Bit: 6
+
 ## <a href="#descriptor" name="descriptor"></a> `descriptor`: `u32`
 
 A descriptor is a reference to a filesystem object, which may be a file,
@@ -576,7 +589,9 @@ from `fdstat_get` in earlier versions of WASI.
 
 #### <a href="#set_flags" name="set_flags"></a> `set-flags` 
 
-Set flags associated with a descriptor.
+Set status flags associated with a descriptor.
+
+This function may only change the `append` and `nonblock` flags.
 
 Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
 
@@ -789,6 +804,15 @@ descriptor not currently open/ it is randomized to prevent applications
 from depending on making assumptions about indexes, since this is
 error-prone in multi-threaded contexts. The returned descriptor is
 guaranteed to be less than 2**31.
+
+If `flags` contains `descriptor-flags::mutate-directory`, and the base
+descriptor doesn't have `descriptor-flags::mutate-directory` set,
+`open-at` fails with `errno::rofs`.
+
+If `flags` contains `write` or `append`, or `o-flags` contains `trunc`
+or `create`, and the base descriptor doesn't have
+`descriptor-flags::mutate-directory` set, `open-at` fails with
+`errno::rofs`.
 
 Note: This is similar to `openat` in POSIX.
 ##### Params

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -87,6 +87,16 @@ flags descriptor-flags {
     /// WASI. At this time, it should be interpreted as a request, and not a
     /// requirement.
     rsync,
+    /// Mutating directories mode: Directory contents may be mutated.
+    ///
+    /// When this flag is unset on a descriptor, operations using the
+    /// descriptor which would create, rename, delete, modify the data or
+    /// metadata of filesystem objects, or obtain another handle which
+    /// would permit any of those, shall fail with `errno::rofs` if
+    /// they would otherwise succeed.
+    ///
+    /// This may only be set on directories.
+    mutate-directory,
 }
 ```
 
@@ -379,7 +389,9 @@ datasync: func(this: descriptor) -> result<_, errno>
 
 ## `set-flags`
 ```wit
-/// Set flags associated with a descriptor.
+/// Set status flags associated with a descriptor.
+///
+/// This function may only change the `append` and `nonblock` flags.
 ///
 /// Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
 ///
@@ -551,6 +563,15 @@ link-at: func(
 /// from depending on making assumptions about indexes, since this is
 /// error-prone in multi-threaded contexts. The returned descriptor is
 /// guaranteed to be less than 2**31.
+///
+/// If `flags` contains `descriptor-flags::mutate-directory`, and the base
+/// descriptor doesn't have `descriptor-flags::mutate-directory` set,
+/// `open-at` fails with `errno::rofs`.
+///
+/// If `flags` contains `write` or `append`, or `o-flags` contains `trunc`
+/// or `create`, and the base descriptor doesn't have
+/// `descriptor-flags::mutate-directory` set, `open-at` fails with
+/// `errno::rofs`.
 ///
 /// Note: This is similar to `openat` in POSIX.
 open-at: func(


### PR DESCRIPTION
Add a `mutate-directory` flag to `descriptor-flags`, and make it a requirement for any filesystem-mutating operation. POSIX compatibility may be provided by setting `mutate-directory` whenever performing a readonly `open-at`.

When this flag is unset on a directory descriptor, the descriptor acts as a readonly directory view.

This is the most notable use case that the "rights" system in preview1 was useful for.