### PR TITLE
Exclude `.` and `..` from directory iteration.

### DIFF
--- a/wasi-filesystem.html
+++ b/wasi-filesystem.html
@@ -588,6 +588,9 @@ the write set to zero.</p>
 <hr />
 <h4><a href="#readdir" name="readdir"></a> <a href="#readdir"><code>readdir</code></a></h4>
 <p>Read directory entries from a directory.</p>
+<p>On filesystems where directories contain entries referring to themselves
+and their parents, often named <code>.</code> and <code>..</code> respectively, these entries
+are omitted.</p>
 <p>This always returns a new stream which starts at the beginning of the
 directory.</p>
 <h5>Params</h5>

--- a/wasi-filesystem.md
+++ b/wasi-filesystem.md
@@ -665,6 +665,10 @@ Note: This is similar to `pwrite` in POSIX.
 
 Read directory entries from a directory.
 
+On filesystems where directories contain entries referring to themselves
+and their parents, often named `.` and `..` respectively, these entries
+are omitted.
+
 This always returns a new stream which starts at the beginning of the
 directory.
 ##### Params

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -450,6 +450,10 @@ pwrite: func(
 ```wit
 /// Read directory entries from a directory.
 ///
+/// On filesystems where directories contain entries referring to themselves
+/// and their parents, often named `.` and `..` respectively, these entries
+/// are omitted.
+///
 /// This always returns a new stream which starts at the beginning of the
 /// directory.
 readdir: func(this: descriptor) -> stream<dir-entry-stream, errno>


### PR DESCRIPTION
Add text excluding `.` and `..` from `readdir` directory iteration. In most use cases, they act as navigational mechanisms rather than meaningful contents of directories.

Wasi-libc will be expected to re-add `.` and `..` when implementing the POSIX `readdir` interface.

Fixes #90.