### PR TITLE
Import `datetime` and the stream types from wasi-clocks and wasi-io.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - run: curl https://raw.githubusercontent.com/WebAssembly/wasi-poll/75ace039473c05928cfd8e6df0243fc47ee9e8c9/wit/wasi-poll.wit.md > wit/wasi-poll.wit.md
+    - run: curl https://raw.githubusercontent.com/WebAssembly/wasi-io/078a05fdc786b7f4ca7217ac6c0dcfa694c31138/wit/wasi-io.wit.md > wit/wasi-io.wit.md
+    - run: curl https://raw.githubusercontent.com/WebAssembly/wasi-clocks/c288ba066db7907028b92e8efa0fbd22f6f25cf7/wit/wasi-wall-clock.wit.md > wit/wasi-wall-clock.wit.md
     - uses: WebAssembly/wit-abi-up-to-date@v10
       with:
         wit-abi-tag: wit-abi-0.8.0

--- a/wasi-filesystem.html
+++ b/wasi-filesystem.html
@@ -874,7 +874,7 @@ directory.</p>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#readdir.result0" name="readdir.result0"></a> <code>result0</code>: stream&lt;<a href="#dir_entry_stream"><a href="#dir_entry_stream"><code>dir-entry-stream</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#readdir.result0" name="readdir.result0"></a> <code>result0</code>: result&lt;<a href="#dir_entry_stream"><a href="#dir_entry_stream"><code>dir-entry-stream</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#sync" name="sync"></a> <a href="#sync"><code>sync</code></a></h4>

--- a/wasi-filesystem.html
+++ b/wasi-filesystem.html
@@ -1,5 +1,260 @@
+<h1>Import interface <code>wasi-poll</code></h1>
+<h2>Types</h2>
+<h2><a href="#pollable" name="pollable"></a> <a href="#pollable"><code>pollable</code></a>: <code>u32</code></h2>
+<p>A &quot;pollable&quot; handle.</p>
+<p>This is conceptually represents a <code>stream&lt;_, _&gt;</code>, or in other words,
+a stream that one can wait on, repeatedly, but which does not itself
+produce any data. It's temporary scaffolding until component-model's
+async features are ready.</p>
+<p>And at present, it is a <code>u32</code> instead of being an actual handle, until
+the wit-bindgen implementation of handles and resources is ready.</p>
+<p><a href="#pollable"><code>pollable</code></a> lifetimes are not automatically managed. Users must ensure
+that they do not outlive the resource they reference.</p>
+<p>Size: 4, Alignment: 4</p>
+<h2>Functions</h2>
+<hr />
+<h4><a href="#poll_oneoff" name="poll_oneoff"></a> <a href="#poll_oneoff"><code>poll-oneoff</code></a></h4>
+<p>Poll for completion on a set of pollables.</p>
+<p>The &quot;oneoff&quot; in the name refers to the fact that this function must do a
+linear scan through the entire list of subscriptions, which may be
+inefficient if the number is large and the same subscriptions are used
+many times. In the future, it may be accompanied by an API similar to
+Linux's <code>epoll</code> which allows sets of subscriptions to be registered and
+made efficiently reusable.</p>
+<p>Note that the return type would ideally be <code>list&lt;bool&gt;</code>, but that would
+be more difficult to polyfill given the current state of <code>wit-bindgen</code>.
+See https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061
+for details.  For now, we use zero to mean &quot;not ready&quot; and non-zero to
+mean &quot;ready&quot;.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#poll_oneoff.in" name="poll_oneoff.in"></a> <code>in</code>: list&lt;<a href="#pollable"><a href="#pollable"><code>pollable</code></a></a>&gt;</li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#poll_oneoff.result0" name="poll_oneoff.result0"></a> <code>result0</code>: list&lt;<code>u8</code>&gt;</li>
+</ul>
+<h1>Import interface <code>wasi-io</code></h1>
+<h2>Types</h2>
+<h2><a href="#pollable" name="pollable"></a> <a href="#pollable"><code>pollable</code></a>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></h2>
+<p>Size: 4, Alignment: 4</p>
+<h2><a href="#stream_error" name="stream_error"></a> <a href="#stream_error"><code>stream-error</code></a>: record</h2>
+<p>An error type returned from a stream operation. Currently this
+doesn't provide any additional information.</p>
+<p>Size: 0, Alignment: 1</p>
+<h3>Record Fields</h3>
+<h2><a href="#output_stream" name="output_stream"></a> <a href="#output_stream"><code>output-stream</code></a>: <code>u32</code></h2>
+<p>An output bytestream. In the future, this will be replaced by handle
+types.</p>
+<p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
+scaffolding until component-model's async features are ready.</p>
+<p>And at present, it is a <code>u32</code> instead of being an actual handle, until
+the wit-bindgen implementation of handles and resources is ready.</p>
+<p>Size: 4, Alignment: 4</p>
+<h2><a href="#input_stream" name="input_stream"></a> <a href="#input_stream"><code>input-stream</code></a>: <code>u32</code></h2>
+<p>An input bytestream. In the future, this will be replaced by handle
+types.</p>
+<p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
+scaffolding until component-model's async features are ready.</p>
+<p>And at present, it is a <code>u32</code> instead of being an actual handle, until
+the wit-bindgen implementation of handles and resources is ready.</p>
+<p>Size: 4, Alignment: 4</p>
+<h2>Functions</h2>
+<hr />
+<h4><a href="#read" name="read"></a> <a href="#read"><code>read</code></a></h4>
+<p>Read bytes from a stream.</p>
+<p>This function returns a list of bytes containing the data that was
+read, along with a bool indicating whether the end of the stream
+was reached. The returned list will contain up to <code>len</code> bytes; it
+may return fewer than requested, but not more.</p>
+<p>Once a stream has reached the end, subsequent calls to read or
+<a href="#skip"><code>skip</code></a> will always report end-of-stream rather than producing more
+data.</p>
+<p>If <code>len</code> is 0, it represents a request to read 0 bytes, which should
+always succeed, assuming the stream hasn't reached its end yet, and
+return an empty list.</p>
+<p>The len here is a <code>u64</code>, but some callees may not be able to allocate
+a buffer as large as that would imply.
+FIXME: describe what happens if allocation fails.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#read.this" name="read.this"></a> <code>this</code>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a href="#read.len" name="read.len"></a> <code>len</code>: <code>u64</code></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#read.result0" name="read.result0"></a> <code>result0</code>: result&lt;(list&lt;<code>u8</code>&gt;, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
+<hr />
+<h4><a href="#skip" name="skip"></a> <a href="#skip"><code>skip</code></a></h4>
+<p>Skip bytes from a stream.</p>
+<p>This is similar to the <a href="#read"><code>read</code></a> function, but avoids copying the
+bytes into the instance.</p>
+<p>Once a stream has reached the end, subsequent calls to read or
+<a href="#skip"><code>skip</code></a> will always report end-of-stream rather than producing more
+data.</p>
+<p>This function returns the number of bytes skipped, along with a bool
+indicating whether the end of the stream was reached. The returned
+value will be at most <code>len</code>; it may be less.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#skip.this" name="skip.this"></a> <code>this</code>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a href="#skip.len" name="skip.len"></a> <code>len</code>: <code>u64</code></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#skip.result0" name="skip.result0"></a> <code>result0</code>: result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
+<hr />
+<h4><a href="#subscribe_read" name="subscribe_read"></a> <a href="#subscribe_read"><code>subscribe-read</code></a></h4>
+<p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream has bytes
+available to read or the other end of the stream has been closed.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#subscribe_read.this" name="subscribe_read.this"></a> <code>this</code>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#subscribe_read.result0" name="subscribe_read.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+</ul>
+<hr />
+<h4><a href="#drop_input_stream" name="drop_input_stream"></a> <a href="#drop_input_stream"><code>drop-input-stream</code></a></h4>
+<p>Dispose of the specified <a href="#input_stream"><code>input-stream</code></a>, after which it may no longer
+be used.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#drop_input_stream.this" name="drop_input_stream.this"></a> <code>this</code>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+</ul>
+<hr />
+<h4><a href="#write" name="write"></a> <a href="#write"><code>write</code></a></h4>
+<p>Write bytes to a stream.</p>
+<p>This function returns a <code>u64</code> indicating the number of bytes from
+<code>buf</code> that were written; it may be less than the full list.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#write.this" name="write.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a href="#write.buf" name="write.buf"></a> <code>buf</code>: list&lt;<code>u8</code>&gt;</li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#write.result0" name="write.result0"></a> <code>result0</code>: result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
+<hr />
+<h4><a href="#write_zeroes" name="write_zeroes"></a> <a href="#write_zeroes"><code>write-zeroes</code></a></h4>
+<p>Write multiple zero bytes to a stream.</p>
+<p>This function returns a <code>u64</code> indicating the number of zero bytes
+that were written; it may be less than <code>len</code>.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#write_zeroes.this" name="write_zeroes.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a href="#write_zeroes.len" name="write_zeroes.len"></a> <code>len</code>: <code>u64</code></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#write_zeroes.result0" name="write_zeroes.result0"></a> <code>result0</code>: result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
+<hr />
+<h4><a href="#splice" name="splice"></a> <a href="#splice"><code>splice</code></a></h4>
+<p>Read from one stream and write to another.</p>
+<p>This function returns the number of bytes transferred; it may be less
+than <code>len</code>.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#splice.this" name="splice.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a href="#splice.src" name="splice.src"></a> <code>src</code>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a href="#splice.len" name="splice.len"></a> <code>len</code>: <code>u64</code></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#splice.result0" name="splice.result0"></a> <code>result0</code>: result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
+<hr />
+<h4><a href="#subscribe" name="subscribe"></a> <a href="#subscribe"><code>subscribe</code></a></h4>
+<p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream is ready
+to accept bytes or the other end of the stream has been closed.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#subscribe.this" name="subscribe.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#subscribe.result0" name="subscribe.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+</ul>
+<hr />
+<h4><a href="#drop_output_stream" name="drop_output_stream"></a> <a href="#drop_output_stream"><code>drop-output-stream</code></a></h4>
+<p>Dispose of the specified <a href="#output_stream"><code>output-stream</code></a>, after which it may no longer
+be used.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#drop_output_stream.this" name="drop_output_stream.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+</ul>
+<h1>Import interface <code>wasi-wall-clock</code></h1>
+<h2>Types</h2>
+<h2><a href="#wall_clock" name="wall_clock"></a> <a href="#wall_clock"><code>wall-clock</code></a>: <code>u32</code></h2>
+<p>A wall clock is a clock which measures the date and time according to some
+external reference.</p>
+<p>External references may be reset, so this clock is not necessarily
+monotonic, making it unsuitable for measuring elapsed time.</p>
+<p>It is intended for reporting the current date and time for humans.</p>
+<p>Size: 4, Alignment: 4</p>
+<h2><a href="#datetime" name="datetime"></a> <a href="#datetime"><code>datetime</code></a>: record</h2>
+<p>A time and date in seconds plus nanoseconds.</p>
+<p>Size: 16, Alignment: 8</p>
+<h3>Record Fields</h3>
+<ul>
+<li>
+<p><a href="datetime.seconds" name="datetime.seconds"></a> <a href="#datetime.seconds"><code>seconds</code></a>: <code>u64</code></p>
+</li>
+<li>
+<p><a href="datetime.nanoseconds" name="datetime.nanoseconds"></a> <a href="#datetime.nanoseconds"><code>nanoseconds</code></a>: <code>u32</code></p>
+</li>
+</ul>
+<h2>Functions</h2>
+<hr />
+<h4><a href="#now" name="now"></a> <a href="#now"><code>now</code></a></h4>
+<p>Read the current value of the clock.</p>
+<p>This clock is not monotonic, therefore calling this function repeatedly will
+not necessarily produce a sequence of non-decreasing values.</p>
+<p>The returned timestamps represent the number of seconds since
+1970-01-01T00:00:00Z, also known as <a href="https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16">POSIX's Seconds Since the Epoch</a>, also
+known as <a href="https://en.wikipedia.org/wiki/Unix_time">Unix Time</a>.</p>
+<p>The nanoseconds field of the output is always less than 1000000000.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#now.this" name="now.this"></a> <code>this</code>: <a href="#wall_clock"><a href="#wall_clock"><code>wall-clock</code></a></a></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#now.result0" name="now.result0"></a> <code>result0</code>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
+</ul>
+<hr />
+<h4><a href="#resolution" name="resolution"></a> <a href="#resolution"><code>resolution</code></a></h4>
+<p>Query the resolution of the clock.</p>
+<p>The nanoseconds field of the output is always less than 1000000000.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#resolution.this" name="resolution.this"></a> <code>this</code>: <a href="#wall_clock"><a href="#wall_clock"><code>wall-clock</code></a></a></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#resolution.result0" name="resolution.result0"></a> <code>result0</code>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></li>
+</ul>
+<hr />
+<h4><a href="#drop_wall_clock" name="drop_wall_clock"></a> <a href="#drop_wall_clock"><code>drop-wall-clock</code></a></h4>
+<p>Dispose of the specified <a href="#wall_clock"><code>wall-clock</code></a>, after which it may no longer
+be used.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#drop_wall_clock.this" name="drop_wall_clock.this"></a> <code>this</code>: <a href="#wall_clock"><a href="#wall_clock"><code>wall-clock</code></a></a></li>
+</ul>
 <h1>Import interface <code>wasi-filesystem</code></h1>
 <h2>Types</h2>
+<h2><a href="#input_stream" name="input_stream"></a> <a href="#input_stream"><code>input-stream</code></a>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></h2>
+<p>Size: 4, Alignment: 4</p>
+<h2><a href="#output_stream" name="output_stream"></a> <a href="#output_stream"><code>output-stream</code></a>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></h2>
+<p>Size: 4, Alignment: 4</p>
+<h2><a href="#datetime" name="datetime"></a> <a href="#datetime"><code>datetime</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></h2>
+<p>Size: 16, Alignment: 8</p>
 <h2><a href="#o_flags" name="o_flags"></a> <a href="#o_flags"><code>o-flags</code></a>: record</h2>
 <p>Open flags used by <a href="#open_at"><code>open-at</code></a>.</p>
 <p>Size: 1, Alignment: 1</p>
@@ -24,25 +279,6 @@ Bit: 2</p>
 <p><a href="o_flags.trunc" name="o_flags.trunc"></a> <a href="#o_flags.trunc"><code>trunc</code></a>: </p>
 <p>Truncate file to size 0.
 Bit: 3</p>
-</li>
-</ul>
-<h2><a href="#new_timestamp" name="new_timestamp"></a> <a href="#new_timestamp"><code>new-timestamp</code></a>: variant</h2>
-<p>When setting a timestamp, this gives the value to set it to.</p>
-<p>Size: 16, Alignment: 8</p>
-<h3>Variant Cases</h3>
-<ul>
-<li>
-<p><a href="new_timestamp.no_change" name="new_timestamp.no_change"></a> <a href="#new_timestamp.no_change"><code>no-change</code></a></p>
-<p>Leave the timestamp set to its previous value.</p>
-</li>
-<li>
-<p><a href="new_timestamp.now" name="new_timestamp.now"></a> <a href="#new_timestamp.now"><code>now</code></a></p>
-<p>Set the timestamp to the current time of the system clock associated
-with the filesystem.</p>
-</li>
-<li>
-<p><a href="new_timestamp.timestamp" name="new_timestamp.timestamp"></a> <a href="#new_timestamp.timestamp"><code>timestamp</code></a>: <code>u64</code></p>
-<p>Set the timestamp to the given value.</p>
 </li>
 </ul>
 <h2><a href="#mode" name="mode"></a> <a href="#mode"><code>mode</code></a>: record</h2>
@@ -309,46 +545,6 @@ implementations which can set this to a non-none value should do so.</p>
 <p>The name of the object.</p>
 </li>
 </ul>
-<h2><a href="#descriptor_stat" name="descriptor_stat"></a> <a href="#descriptor_stat"><code>descriptor-stat</code></a>: record</h2>
-<p>File attributes.</p>
-<p>Note: This was called <code>filestat</code> in earlier versions of WASI.</p>
-<p>Size: 64, Alignment: 8</p>
-<h3>Record Fields</h3>
-<ul>
-<li>
-<p><a href="descriptor_stat.dev" name="descriptor_stat.dev"></a> <a href="#descriptor_stat.dev"><code>dev</code></a>: <a href="#device"><a href="#device"><code>device</code></a></a></p>
-<p>Device ID of device containing the file.</p>
-</li>
-<li>
-<p><a href="descriptor_stat.ino" name="descriptor_stat.ino"></a> <a href="#descriptor_stat.ino"><code>ino</code></a>: <a href="#inode"><a href="#inode"><code>inode</code></a></a></p>
-<p>File serial number.</p>
-</li>
-<li>
-<p><a href="descriptor_stat.type" name="descriptor_stat.type"></a> <a href="#descriptor_stat.type"><a href="#type"><code>type</code></a></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
-<p>File type.</p>
-</li>
-<li>
-<p><a href="descriptor_stat.nlink" name="descriptor_stat.nlink"></a> <a href="#descriptor_stat.nlink"><code>nlink</code></a>: <a href="#linkcount"><a href="#linkcount"><code>linkcount</code></a></a></p>
-<p>Number of hard links to the file.</p>
-</li>
-<li>
-<p><a href="descriptor_stat.size" name="descriptor_stat.size"></a> <a href="#descriptor_stat.size"><code>size</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></p>
-<p>For regular files, the file size in bytes. For symbolic links, the length
-in bytes of the pathname contained in the symbolic link.</p>
-</li>
-<li>
-<p><a href="descriptor_stat.atim" name="descriptor_stat.atim"></a> <a href="#descriptor_stat.atim"><code>atim</code></a>: <code>u64</code></p>
-<p>Last data access timestamp.</p>
-</li>
-<li>
-<p><a href="descriptor_stat.mtim" name="descriptor_stat.mtim"></a> <a href="#descriptor_stat.mtim"><code>mtim</code></a>: <code>u64</code></p>
-<p>Last data modification timestamp.</p>
-</li>
-<li>
-<p><a href="descriptor_stat.ctim" name="descriptor_stat.ctim"></a> <a href="#descriptor_stat.ctim"><code>ctim</code></a>: <code>u64</code></p>
-<p>Last file status change timestamp.</p>
-</li>
-</ul>
 <h2><a href="#descriptor_flags" name="descriptor_flags"></a> <a href="#descriptor_flags"><code>descriptor-flags</code></a>: record</h2>
 <p>Descriptor flags.</p>
 <p>Note: This was called <code>fdflags</code> in earlier versions of WASI.</p>
@@ -356,12 +552,12 @@ in bytes of the pathname contained in the symbolic link.</p>
 <h3>Record Fields</h3>
 <ul>
 <li>
-<p><a href="descriptor_flags.read" name="descriptor_flags.read"></a> <a href="#descriptor_flags.read"><code>read</code></a>: </p>
+<p><a href="descriptor_flags.read" name="descriptor_flags.read"></a> <a href="#descriptor_flags.read"><a href="#read"><code>read</code></a></a>: </p>
 <p>Read mode: Data can be read.
 Bit: 0</p>
 </li>
 <li>
-<p><a href="descriptor_flags.write" name="descriptor_flags.write"></a> <a href="#descriptor_flags.write"><code>write</code></a>: </p>
+<p><a href="descriptor_flags.write" name="descriptor_flags.write"></a> <a href="#descriptor_flags.write"><a href="#write"><code>write</code></a></a>: </p>
 <p>Write mode: Data can be written to.
 Bit: 1</p>
 </li>
@@ -394,6 +590,65 @@ Bit: 5</p>
 directory, named pipe, special file, or other object on which filesystem
 calls may be made.</p>
 <p>Size: 4, Alignment: 4</p>
+<h2><a href="#new_timestamp" name="new_timestamp"></a> <a href="#new_timestamp"><code>new-timestamp</code></a>: variant</h2>
+<p>When setting a timestamp, this gives the value to set it to.</p>
+<p>Size: 24, Alignment: 8</p>
+<h3>Variant Cases</h3>
+<ul>
+<li>
+<p><a href="new_timestamp.no_change" name="new_timestamp.no_change"></a> <a href="#new_timestamp.no_change"><code>no-change</code></a></p>
+<p>Leave the timestamp set to its previous value.</p>
+</li>
+<li>
+<p><a href="new_timestamp.now" name="new_timestamp.now"></a> <a href="#new_timestamp.now"><a href="#now"><code>now</code></a></a></p>
+<p>Set the timestamp to the current time of the system clock associated
+with the filesystem.</p>
+</li>
+<li>
+<p><a href="new_timestamp.timestamp" name="new_timestamp.timestamp"></a> <a href="#new_timestamp.timestamp"><code>timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Set the timestamp to the given value.</p>
+</li>
+</ul>
+<h2><a href="#descriptor_stat" name="descriptor_stat"></a> <a href="#descriptor_stat"><code>descriptor-stat</code></a>: record</h2>
+<p>File attributes.</p>
+<p>Note: This was called <code>filestat</code> in earlier versions of WASI.</p>
+<p>Size: 88, Alignment: 8</p>
+<h3>Record Fields</h3>
+<ul>
+<li>
+<p><a href="descriptor_stat.dev" name="descriptor_stat.dev"></a> <a href="#descriptor_stat.dev"><code>dev</code></a>: <a href="#device"><a href="#device"><code>device</code></a></a></p>
+<p>Device ID of device containing the file.</p>
+</li>
+<li>
+<p><a href="descriptor_stat.ino" name="descriptor_stat.ino"></a> <a href="#descriptor_stat.ino"><code>ino</code></a>: <a href="#inode"><a href="#inode"><code>inode</code></a></a></p>
+<p>File serial number.</p>
+</li>
+<li>
+<p><a href="descriptor_stat.type" name="descriptor_stat.type"></a> <a href="#descriptor_stat.type"><a href="#type"><code>type</code></a></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
+<p>File type.</p>
+</li>
+<li>
+<p><a href="descriptor_stat.nlink" name="descriptor_stat.nlink"></a> <a href="#descriptor_stat.nlink"><code>nlink</code></a>: <a href="#linkcount"><a href="#linkcount"><code>linkcount</code></a></a></p>
+<p>Number of hard links to the file.</p>
+</li>
+<li>
+<p><a href="descriptor_stat.size" name="descriptor_stat.size"></a> <a href="#descriptor_stat.size"><code>size</code></a>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></p>
+<p>For regular files, the file size in bytes. For symbolic links, the length
+in bytes of the pathname contained in the symbolic link.</p>
+</li>
+<li>
+<p><a href="descriptor_stat.atim" name="descriptor_stat.atim"></a> <a href="#descriptor_stat.atim"><code>atim</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Last data access timestamp.</p>
+</li>
+<li>
+<p><a href="descriptor_stat.mtim" name="descriptor_stat.mtim"></a> <a href="#descriptor_stat.mtim"><code>mtim</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Last data modification timestamp.</p>
+</li>
+<li>
+<p><a href="descriptor_stat.ctim" name="descriptor_stat.ctim"></a> <a href="#descriptor_stat.ctim"><code>ctim</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p>Last file status change timestamp.</p>
+</li>
+</ul>
 <h2><a href="#at_flags" name="at_flags"></a> <a href="#at_flags"><code>at-flags</code></a>: record</h2>
 <p>Flags determining the method of how paths are resolved.</p>
 <p>Size: 1, Alignment: 1</p>
@@ -436,6 +691,46 @@ Bit: 0</p>
 </li>
 </ul>
 <h2>Functions</h2>
+<hr />
+<h4><a href="#read_via_stream" name="read_via_stream"></a> <a href="#read_via_stream"><code>read-via-stream</code></a></h4>
+<p>Return a stream for reading from a file.</p>
+<p>Note: This allows using <code>read-stream</code>, which is similar to <a href="#read"><code>read</code></a> in POSIX.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#read_via_stream.this" name="read_via_stream.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a href="#read_via_stream.offset" name="read_via_stream.offset"></a> <code>offset</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#read_via_stream.result0" name="read_via_stream.result0"></a> <code>result0</code>: result&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+</ul>
+<hr />
+<h4><a href="#write_via_stream" name="write_via_stream"></a> <a href="#write_via_stream"><code>write-via-stream</code></a></h4>
+<p>Return a stream for writing to a file.</p>
+<p>Note: This allows using <code>write-stream</code>, which is similar to <a href="#write"><code>write</code></a> in POSIX.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#write_via_stream.this" name="write_via_stream.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a href="#write_via_stream.offset" name="write_via_stream.offset"></a> <code>offset</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#write_via_stream.result0" name="write_via_stream.result0"></a> <code>result0</code>: result&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+</ul>
+<hr />
+<h4><a href="#append_via_stream" name="append_via_stream"></a> <a href="#append_via_stream"><code>append-via-stream</code></a></h4>
+<p>Return a stream for appending to a file.</p>
+<p>Note: This allows using <code>write-stream</code>, which is similar to <a href="#write"><code>write</code></a> with
+<code>O_APPEND</code> in in POSIX.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#append_via_stream.this" name="append_via_stream.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a href="#append_via_stream.fd" name="append_via_stream.fd"></a> <code>fd</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#append_via_stream.result0" name="append_via_stream.result0"></a> <code>result0</code>: result&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+</ul>
 <hr />
 <h4><a href="#fadvise" name="fadvise"></a> <a href="#fadvise"><code>fadvise</code></a></h4>
 <p>Provide file advisory information on a descriptor.</p>
@@ -782,7 +1077,7 @@ filesystem-specific.</p>
 <p>Note that the ultimate meanings of these permissions is
 filesystem-specific.</p>
 <p>Unlike in POSIX, the <code>executable</code> flag is not reinterpreted as a &quot;search&quot;
-flag. <code>read</code> on a directory implies readability and searchability, and
+flag. <a href="#read"><code>read</code></a> on a directory implies readability and searchability, and
 <code>execute</code> is not valid for directories.</p>
 <p>Note: This is similar to <code>fchmodat</code> in POSIX.</p>
 <h5>Params</h5>

--- a/wasi-filesystem.md
+++ b/wasi-filesystem.md
@@ -1034,7 +1034,7 @@ directory.
 - <a href="#readdir.this" name="readdir.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#readdir.result0" name="readdir.result0"></a> `result0`: stream<[`dir-entry-stream`](#dir_entry_stream), [`errno`](#errno)>
+- <a href="#readdir.result0" name="readdir.result0"></a> `result0`: result<[`dir-entry-stream`](#dir_entry_stream), [`errno`](#errno)>
 
 ----
 

--- a/wasi-filesystem.md
+++ b/wasi-filesystem.md
@@ -1,6 +1,344 @@
+# Import interface `wasi-poll`
+
+## Types
+
+## <a href="#pollable" name="pollable"></a> `pollable`: `u32`
+
+A "pollable" handle.
+
+This is conceptually represents a `stream<_, _>`, or in other words,
+a stream that one can wait on, repeatedly, but which does not itself
+produce any data. It's temporary scaffolding until component-model's
+async features are ready.
+
+And at present, it is a `u32` instead of being an actual handle, until
+the wit-bindgen implementation of handles and resources is ready.
+
+`pollable` lifetimes are not automatically managed. Users must ensure
+that they do not outlive the resource they reference.
+
+Size: 4, Alignment: 4
+
+## Functions
+
+----
+
+#### <a href="#poll_oneoff" name="poll_oneoff"></a> `poll-oneoff` 
+
+Poll for completion on a set of pollables.
+
+The "oneoff" in the name refers to the fact that this function must do a
+linear scan through the entire list of subscriptions, which may be
+inefficient if the number is large and the same subscriptions are used
+many times. In the future, it may be accompanied by an API similar to
+Linux's `epoll` which allows sets of subscriptions to be registered and
+made efficiently reusable.
+
+Note that the return type would ideally be `list<bool>`, but that would
+be more difficult to polyfill given the current state of `wit-bindgen`.
+See https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061
+for details.  For now, we use zero to mean "not ready" and non-zero to
+mean "ready".
+##### Params
+
+- <a href="#poll_oneoff.in" name="poll_oneoff.in"></a> `in`: list<[`pollable`](#pollable)>
+##### Results
+
+- <a href="#poll_oneoff.result0" name="poll_oneoff.result0"></a> `result0`: list<`u8`>
+
+# Import interface `wasi-io`
+
+## Types
+
+## <a href="#pollable" name="pollable"></a> `pollable`: [`pollable`](#pollable)
+
+
+Size: 4, Alignment: 4
+
+## <a href="#stream_error" name="stream_error"></a> `stream-error`: record
+
+An error type returned from a stream operation. Currently this
+doesn't provide any additional information.
+
+Size: 0, Alignment: 1
+
+### Record Fields
+
+## <a href="#output_stream" name="output_stream"></a> `output-stream`: `u32`
+
+An output bytestream. In the future, this will be replaced by handle
+types.
+
+This conceptually represents a `stream<u8, _>`. It's temporary
+scaffolding until component-model's async features are ready.
+
+And at present, it is a `u32` instead of being an actual handle, until
+the wit-bindgen implementation of handles and resources is ready.
+
+Size: 4, Alignment: 4
+
+## <a href="#input_stream" name="input_stream"></a> `input-stream`: `u32`
+
+An input bytestream. In the future, this will be replaced by handle
+types.
+
+This conceptually represents a `stream<u8, _>`. It's temporary
+scaffolding until component-model's async features are ready.
+
+And at present, it is a `u32` instead of being an actual handle, until
+the wit-bindgen implementation of handles and resources is ready.
+
+Size: 4, Alignment: 4
+
+## Functions
+
+----
+
+#### <a href="#read" name="read"></a> `read` 
+
+Read bytes from a stream.
+
+This function returns a list of bytes containing the data that was
+read, along with a bool indicating whether the end of the stream
+was reached. The returned list will contain up to `len` bytes; it
+may return fewer than requested, but not more.
+
+Once a stream has reached the end, subsequent calls to read or
+`skip` will always report end-of-stream rather than producing more
+data.
+
+If `len` is 0, it represents a request to read 0 bytes, which should
+always succeed, assuming the stream hasn't reached its end yet, and
+return an empty list.
+
+The len here is a `u64`, but some callees may not be able to allocate
+a buffer as large as that would imply.
+FIXME: describe what happens if allocation fails.
+##### Params
+
+- <a href="#read.this" name="read.this"></a> `this`: [`input-stream`](#input_stream)
+- <a href="#read.len" name="read.len"></a> `len`: `u64`
+##### Results
+
+- <a href="#read.result0" name="read.result0"></a> `result0`: result<(list<`u8`>, `bool`), [`stream-error`](#stream_error)>
+
+----
+
+#### <a href="#skip" name="skip"></a> `skip` 
+
+Skip bytes from a stream.
+
+This is similar to the `read` function, but avoids copying the
+bytes into the instance.
+
+Once a stream has reached the end, subsequent calls to read or
+`skip` will always report end-of-stream rather than producing more
+data.
+
+This function returns the number of bytes skipped, along with a bool
+indicating whether the end of the stream was reached. The returned
+value will be at most `len`; it may be less.
+##### Params
+
+- <a href="#skip.this" name="skip.this"></a> `this`: [`input-stream`](#input_stream)
+- <a href="#skip.len" name="skip.len"></a> `len`: `u64`
+##### Results
+
+- <a href="#skip.result0" name="skip.result0"></a> `result0`: result<(`u64`, `bool`), [`stream-error`](#stream_error)>
+
+----
+
+#### <a href="#subscribe_read" name="subscribe_read"></a> `subscribe-read` 
+
+Create a `pollable` which will resolve once either the specified stream has bytes
+available to read or the other end of the stream has been closed.
+##### Params
+
+- <a href="#subscribe_read.this" name="subscribe_read.this"></a> `this`: [`input-stream`](#input_stream)
+##### Results
+
+- <a href="#subscribe_read.result0" name="subscribe_read.result0"></a> `result0`: [`pollable`](#pollable)
+
+----
+
+#### <a href="#drop_input_stream" name="drop_input_stream"></a> `drop-input-stream` 
+
+Dispose of the specified `input-stream`, after which it may no longer
+be used.
+##### Params
+
+- <a href="#drop_input_stream.this" name="drop_input_stream.this"></a> `this`: [`input-stream`](#input_stream)
+
+----
+
+#### <a href="#write" name="write"></a> `write` 
+
+Write bytes to a stream.
+
+This function returns a `u64` indicating the number of bytes from
+`buf` that were written; it may be less than the full list.
+##### Params
+
+- <a href="#write.this" name="write.this"></a> `this`: [`output-stream`](#output_stream)
+- <a href="#write.buf" name="write.buf"></a> `buf`: list<`u8`>
+##### Results
+
+- <a href="#write.result0" name="write.result0"></a> `result0`: result<`u64`, [`stream-error`](#stream_error)>
+
+----
+
+#### <a href="#write_zeroes" name="write_zeroes"></a> `write-zeroes` 
+
+Write multiple zero bytes to a stream.
+
+This function returns a `u64` indicating the number of zero bytes
+that were written; it may be less than `len`.
+##### Params
+
+- <a href="#write_zeroes.this" name="write_zeroes.this"></a> `this`: [`output-stream`](#output_stream)
+- <a href="#write_zeroes.len" name="write_zeroes.len"></a> `len`: `u64`
+##### Results
+
+- <a href="#write_zeroes.result0" name="write_zeroes.result0"></a> `result0`: result<`u64`, [`stream-error`](#stream_error)>
+
+----
+
+#### <a href="#splice" name="splice"></a> `splice` 
+
+Read from one stream and write to another.
+
+This function returns the number of bytes transferred; it may be less
+than `len`.
+##### Params
+
+- <a href="#splice.this" name="splice.this"></a> `this`: [`output-stream`](#output_stream)
+- <a href="#splice.src" name="splice.src"></a> `src`: [`input-stream`](#input_stream)
+- <a href="#splice.len" name="splice.len"></a> `len`: `u64`
+##### Results
+
+- <a href="#splice.result0" name="splice.result0"></a> `result0`: result<(`u64`, `bool`), [`stream-error`](#stream_error)>
+
+----
+
+#### <a href="#subscribe" name="subscribe"></a> `subscribe` 
+
+Create a `pollable` which will resolve once either the specified stream is ready
+to accept bytes or the other end of the stream has been closed.
+##### Params
+
+- <a href="#subscribe.this" name="subscribe.this"></a> `this`: [`output-stream`](#output_stream)
+##### Results
+
+- <a href="#subscribe.result0" name="subscribe.result0"></a> `result0`: [`pollable`](#pollable)
+
+----
+
+#### <a href="#drop_output_stream" name="drop_output_stream"></a> `drop-output-stream` 
+
+Dispose of the specified `output-stream`, after which it may no longer
+be used.
+##### Params
+
+- <a href="#drop_output_stream.this" name="drop_output_stream.this"></a> `this`: [`output-stream`](#output_stream)
+
+# Import interface `wasi-wall-clock`
+
+## Types
+
+## <a href="#wall_clock" name="wall_clock"></a> `wall-clock`: `u32`
+
+A wall clock is a clock which measures the date and time according to some
+external reference.
+
+External references may be reset, so this clock is not necessarily
+monotonic, making it unsuitable for measuring elapsed time.
+
+It is intended for reporting the current date and time for humans.
+
+Size: 4, Alignment: 4
+
+## <a href="#datetime" name="datetime"></a> `datetime`: record
+
+A time and date in seconds plus nanoseconds.
+
+Size: 16, Alignment: 8
+
+### Record Fields
+
+- <a href="datetime.seconds" name="datetime.seconds"></a> [`seconds`](#datetime.seconds): `u64`
+  
+  
+- <a href="datetime.nanoseconds" name="datetime.nanoseconds"></a> [`nanoseconds`](#datetime.nanoseconds): `u32`
+  
+  
+## Functions
+
+----
+
+#### <a href="#now" name="now"></a> `now` 
+
+Read the current value of the clock.
+
+This clock is not monotonic, therefore calling this function repeatedly will
+not necessarily produce a sequence of non-decreasing values.
+
+The returned timestamps represent the number of seconds since
+1970-01-01T00:00:00Z, also known as [POSIX's Seconds Since the Epoch], also
+known as [Unix Time].
+
+The nanoseconds field of the output is always less than 1000000000.
+
+[POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
+[Unix Time]: https://en.wikipedia.org/wiki/Unix_time
+##### Params
+
+- <a href="#now.this" name="now.this"></a> `this`: [`wall-clock`](#wall_clock)
+##### Results
+
+- <a href="#now.result0" name="now.result0"></a> `result0`: [`datetime`](#datetime)
+
+----
+
+#### <a href="#resolution" name="resolution"></a> `resolution` 
+
+Query the resolution of the clock.
+
+The nanoseconds field of the output is always less than 1000000000.
+##### Params
+
+- <a href="#resolution.this" name="resolution.this"></a> `this`: [`wall-clock`](#wall_clock)
+##### Results
+
+- <a href="#resolution.result0" name="resolution.result0"></a> `result0`: [`datetime`](#datetime)
+
+----
+
+#### <a href="#drop_wall_clock" name="drop_wall_clock"></a> `drop-wall-clock` 
+
+Dispose of the specified `wall-clock`, after which it may no longer
+be used.
+##### Params
+
+- <a href="#drop_wall_clock.this" name="drop_wall_clock.this"></a> `this`: [`wall-clock`](#wall_clock)
+
 # Import interface `wasi-filesystem`
 
 ## Types
+
+## <a href="#input_stream" name="input_stream"></a> `input-stream`: [`input-stream`](#input_stream)
+
+
+Size: 4, Alignment: 4
+
+## <a href="#output_stream" name="output_stream"></a> `output-stream`: [`output-stream`](#output_stream)
+
+
+Size: 4, Alignment: 4
+
+## <a href="#datetime" name="datetime"></a> `datetime`: [`datetime`](#datetime)
+
+
+Size: 16, Alignment: 8
 
 ## <a href="#o_flags" name="o_flags"></a> `o-flags`: record
 
@@ -30,27 +368,6 @@ Size: 1, Alignment: 1
   Truncate file to size 0.
   Bit: 3
 
-## <a href="#new_timestamp" name="new_timestamp"></a> `new-timestamp`: variant
-
-When setting a timestamp, this gives the value to set it to.
-
-Size: 16, Alignment: 8
-
-### Variant Cases
-
-- <a href="new_timestamp.no_change" name="new_timestamp.no_change"></a> [`no-change`](#new_timestamp.no_change)
-  
-  Leave the timestamp set to its previous value.
-  
-- <a href="new_timestamp.now" name="new_timestamp.now"></a> [`now`](#new_timestamp.now)
-  
-  Set the timestamp to the current time of the system clock associated
-  with the filesystem.
-  
-- <a href="new_timestamp.timestamp" name="new_timestamp.timestamp"></a> [`timestamp`](#new_timestamp.timestamp): `u64`
-  
-  Set the timestamp to the given value.
-  
 ## <a href="#mode" name="mode"></a> `mode`: record
 
 Permissions mode used by `open-at`, `change-file-permissions-at`, and
@@ -340,49 +657,6 @@ Size: 32, Alignment: 8
   
   The name of the object.
   
-## <a href="#descriptor_stat" name="descriptor_stat"></a> `descriptor-stat`: record
-
-File attributes.
-
-Note: This was called `filestat` in earlier versions of WASI.
-
-Size: 64, Alignment: 8
-
-### Record Fields
-
-- <a href="descriptor_stat.dev" name="descriptor_stat.dev"></a> [`dev`](#descriptor_stat.dev): [`device`](#device)
-  
-  Device ID of device containing the file.
-  
-- <a href="descriptor_stat.ino" name="descriptor_stat.ino"></a> [`ino`](#descriptor_stat.ino): [`inode`](#inode)
-  
-  File serial number.
-  
-- <a href="descriptor_stat.type" name="descriptor_stat.type"></a> [`type`](#descriptor_stat.type): [`descriptor-type`](#descriptor_type)
-  
-  File type.
-  
-- <a href="descriptor_stat.nlink" name="descriptor_stat.nlink"></a> [`nlink`](#descriptor_stat.nlink): [`linkcount`](#linkcount)
-  
-  Number of hard links to the file.
-  
-- <a href="descriptor_stat.size" name="descriptor_stat.size"></a> [`size`](#descriptor_stat.size): [`filesize`](#filesize)
-  
-  For regular files, the file size in bytes. For symbolic links, the length
-  in bytes of the pathname contained in the symbolic link.
-  
-- <a href="descriptor_stat.atim" name="descriptor_stat.atim"></a> [`atim`](#descriptor_stat.atim): `u64`
-  
-  Last data access timestamp.
-  
-- <a href="descriptor_stat.mtim" name="descriptor_stat.mtim"></a> [`mtim`](#descriptor_stat.mtim): `u64`
-  
-  Last data modification timestamp.
-  
-- <a href="descriptor_stat.ctim" name="descriptor_stat.ctim"></a> [`ctim`](#descriptor_stat.ctim): `u64`
-  
-  Last file status change timestamp.
-  
 ## <a href="#descriptor_flags" name="descriptor_flags"></a> `descriptor-flags`: record
 
 Descriptor flags.
@@ -434,6 +708,70 @@ calls may be made.
 
 Size: 4, Alignment: 4
 
+## <a href="#new_timestamp" name="new_timestamp"></a> `new-timestamp`: variant
+
+When setting a timestamp, this gives the value to set it to.
+
+Size: 24, Alignment: 8
+
+### Variant Cases
+
+- <a href="new_timestamp.no_change" name="new_timestamp.no_change"></a> [`no-change`](#new_timestamp.no_change)
+  
+  Leave the timestamp set to its previous value.
+  
+- <a href="new_timestamp.now" name="new_timestamp.now"></a> [`now`](#new_timestamp.now)
+  
+  Set the timestamp to the current time of the system clock associated
+  with the filesystem.
+  
+- <a href="new_timestamp.timestamp" name="new_timestamp.timestamp"></a> [`timestamp`](#new_timestamp.timestamp): [`datetime`](#datetime)
+  
+  Set the timestamp to the given value.
+  
+## <a href="#descriptor_stat" name="descriptor_stat"></a> `descriptor-stat`: record
+
+File attributes.
+
+Note: This was called `filestat` in earlier versions of WASI.
+
+Size: 88, Alignment: 8
+
+### Record Fields
+
+- <a href="descriptor_stat.dev" name="descriptor_stat.dev"></a> [`dev`](#descriptor_stat.dev): [`device`](#device)
+  
+  Device ID of device containing the file.
+  
+- <a href="descriptor_stat.ino" name="descriptor_stat.ino"></a> [`ino`](#descriptor_stat.ino): [`inode`](#inode)
+  
+  File serial number.
+  
+- <a href="descriptor_stat.type" name="descriptor_stat.type"></a> [`type`](#descriptor_stat.type): [`descriptor-type`](#descriptor_type)
+  
+  File type.
+  
+- <a href="descriptor_stat.nlink" name="descriptor_stat.nlink"></a> [`nlink`](#descriptor_stat.nlink): [`linkcount`](#linkcount)
+  
+  Number of hard links to the file.
+  
+- <a href="descriptor_stat.size" name="descriptor_stat.size"></a> [`size`](#descriptor_stat.size): [`filesize`](#filesize)
+  
+  For regular files, the file size in bytes. For symbolic links, the length
+  in bytes of the pathname contained in the symbolic link.
+  
+- <a href="descriptor_stat.atim" name="descriptor_stat.atim"></a> [`atim`](#descriptor_stat.atim): [`datetime`](#datetime)
+  
+  Last data access timestamp.
+  
+- <a href="descriptor_stat.mtim" name="descriptor_stat.mtim"></a> [`mtim`](#descriptor_stat.mtim): [`datetime`](#datetime)
+  
+  Last data modification timestamp.
+  
+- <a href="descriptor_stat.ctim" name="descriptor_stat.ctim"></a> [`ctim`](#descriptor_stat.ctim): [`datetime`](#datetime)
+  
+  Last file status change timestamp.
+  
 ## <a href="#at_flags" name="at_flags"></a> `at-flags`: record
 
 Flags determining the method of how paths are resolved.
@@ -480,6 +818,52 @@ Size: 1, Alignment: 1
   The application expects to access the specified data once and then not reuse it thereafter.
   
 ## Functions
+
+----
+
+#### <a href="#read_via_stream" name="read_via_stream"></a> `read-via-stream` 
+
+Return a stream for reading from a file.
+
+Note: This allows using `read-stream`, which is similar to `read` in POSIX.
+##### Params
+
+- <a href="#read_via_stream.this" name="read_via_stream.this"></a> `this`: [`descriptor`](#descriptor)
+- <a href="#read_via_stream.offset" name="read_via_stream.offset"></a> `offset`: [`filesize`](#filesize)
+##### Results
+
+- <a href="#read_via_stream.result0" name="read_via_stream.result0"></a> `result0`: result<[`input-stream`](#input_stream), [`errno`](#errno)>
+
+----
+
+#### <a href="#write_via_stream" name="write_via_stream"></a> `write-via-stream` 
+
+Return a stream for writing to a file.
+
+Note: This allows using `write-stream`, which is similar to `write` in POSIX.
+##### Params
+
+- <a href="#write_via_stream.this" name="write_via_stream.this"></a> `this`: [`descriptor`](#descriptor)
+- <a href="#write_via_stream.offset" name="write_via_stream.offset"></a> `offset`: [`filesize`](#filesize)
+##### Results
+
+- <a href="#write_via_stream.result0" name="write_via_stream.result0"></a> `result0`: result<[`output-stream`](#output_stream), [`errno`](#errno)>
+
+----
+
+#### <a href="#append_via_stream" name="append_via_stream"></a> `append-via-stream` 
+
+Return a stream for appending to a file.
+
+Note: This allows using `write-stream`, which is similar to `write` with
+`O_APPEND` in in POSIX.
+##### Params
+
+- <a href="#append_via_stream.this" name="append_via_stream.this"></a> `this`: [`descriptor`](#descriptor)
+- <a href="#append_via_stream.fd" name="append_via_stream.fd"></a> `fd`: [`descriptor`](#descriptor)
+##### Results
+
+- <a href="#append_via_stream.result0" name="append_via_stream.result0"></a> `result0`: result<[`output-stream`](#output_stream), [`errno`](#errno)>
 
 ----
 

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -15,6 +15,12 @@
 default interface wasi-filesystem {
 ```
 
+# Imports
+```wit
+use pkg.wasi-io.{input-stream, output-stream}
+use pkg.wasi-wall-clock.{datetime}
+```
+
 ## `filesize`
 ```wit
 /// File size or length of a region within a file.
@@ -89,11 +95,11 @@ record descriptor-stat {
     /// in bytes of the pathname contained in the symbolic link.
     size: filesize,
     /// Last data access timestamp.
-    atim: u64,
+    atim: datetime,
     /// Last data modification timestamp.
-    mtim: u64,
+    mtim: datetime,
     /// Last file status change timestamp.
-    ctim: u64,
+    ctim: datetime,
 }
 ```
 
@@ -167,7 +173,7 @@ variant new-timestamp {
     /// with the filesystem.
     now,
     /// Set the timestamp to the given value.
-    timestamp(u64),
+    timestamp(datetime),
 }
 ```
 
@@ -303,6 +309,43 @@ enum advice {
 /// calls may be made.
 // TODO(resource descriptor {)
 type descriptor = u32
+```
+
+## `read-via-stream`
+```wit
+/// Return a stream for reading from a file.
+///
+/// Note: This allows using `read-stream`, which is similar to `read` in POSIX.
+read-via-stream: func(
+    this: descriptor,
+    /// The offset within the file at which to start reading.
+    offset: filesize,
+) -> result<input-stream, errno>
+```
+
+## `write-via-stream`
+```wit
+/// Return a stream for writing to a file.
+///
+/// Note: This allows using `write-stream`, which is similar to `write` in POSIX.
+write-via-stream: func(
+    this: descriptor,
+    /// The offset within the file at which to start writing.
+    offset: filesize,
+) -> result<output-stream, errno>
+```
+
+## `append-via-stream`
+```wit
+/// Return a stream for appending to a file.
+///
+/// Note: This allows using `write-stream`, which is similar to `write` with
+/// `O_APPEND` in in POSIX.
+append-via-stream: func(
+    this: descriptor,
+    /// The resource to operate on.
+    fd: descriptor,
+) -> result<output-stream, errno>
 ```
 
 ## `fadvise`

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -473,7 +473,7 @@ pwrite: func(
 ///
 /// This always returns a new stream which starts at the beginning of the
 /// directory.
-readdir: func(this: descriptor) -> stream<dir-entry-stream, errno>
+readdir: func(this: descriptor) -> result<dir-entry-stream, errno>
 ```
 
 ## `sync`


### PR DESCRIPTION
Add `read-via-stream`, `write-via-stream`, and `append-via-stream` methods to read from, write to, and append to files. And use the wasi-clocks datetime time for filesystem timestamps.

This uses the same low-tech dependency mechanism as wasi-clocks and wasi-io are currently using to depend on wasi-poll, which will likely evolve.