### PR TITLE
Fix the extra argument to `append-via-stream`, and misc. doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ defined behaviors, which would conflict with the goal of being efficient.
 
 #### Opening a file
 
-```rust=
+```rust
 /// Write "Hello, World" into a file called "greeting.txt" in `dir`.
 fn write_hello_world_to_a_file(dir: Descriptor) -> Result<(), Errno> {
     let at_flags = AtFlags::FollowSymlinks;

--- a/wasi-filesystem.html
+++ b/wasi-filesystem.html
@@ -55,6 +55,12 @@ doesn't provide any additional information.</p>
 types.</p>
 <p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
 scaffolding until component-model's async features are ready.</p>
+<p><a href="#output_stream"><code>output-stream</code></a>s are <em>non-blocking</em> to the extent practical on
+underlying platforms. Except where specified otherwise, I/O operations also
+always return promptly, after the number of bytes that can be written
+promptly, which could even be zero. To wait for the stream to be ready to
+accept data, the <a href="#subscribe_to_output_stream"><code>subscribe-to-output-stream</code></a> function to obtain a
+<a href="#pollable"><code>pollable</code></a> which can be polled for using <code>wasi_poll</code>.</p>
 <p>And at present, it is a <code>u32</code> instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.</p>
 <p>Size: 4, Alignment: 4</p>
@@ -63,6 +69,12 @@ the wit-bindgen implementation of handles and resources is ready.</p>
 types.</p>
 <p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
 scaffolding until component-model's async features are ready.</p>
+<p><a href="#input_stream"><code>input-stream</code></a>s are <em>non-blocking</em> to the extent practical on underlying
+platforms. I/O operations always return promptly; if fewer bytes are
+promptly available than requested, they return the number of bytes promptly
+available, which could even be zero. To wait for data to be available,
+use the <a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a> function to obtain a <a href="#pollable"><code>pollable</code></a> which
+can be polled for using <code>wasi_poll</code>.</p>
 <p>And at present, it is a <code>u32</code> instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.</p>
 <p>Size: 4, Alignment: 4</p>
@@ -165,6 +177,8 @@ that were written; it may be less than <code>len</code>.</p>
 <p>Read from one stream and write to another.</p>
 <p>This function returns the number of bytes transferred; it may be less
 than <code>len</code>.</p>
+<p>Unlike other I/O functions, this function blocks until all the data
+read from the input stream has been written to the output stream.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#splice.this" name="splice.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
@@ -181,6 +195,9 @@ than <code>len</code>.</p>
 <p>This function repeatedly reads from the input stream and writes
 the data to the output stream, until the end of the input stream
 is reached, or an error is encountered.</p>
+<p>Unlike other I/O functions, this function blocks until the end
+of the input stream is seen and all the data has been written to
+the output stream.</p>
 <p>This function returns the number of bytes transferred.</p>
 <h5>Params</h5>
 <ul>
@@ -278,58 +295,69 @@ be used.</p>
 <p>Size: 4, Alignment: 4</p>
 <h2><a href="#datetime" name="datetime"></a> <a href="#datetime"><code>datetime</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></h2>
 <p>Size: 16, Alignment: 8</p>
-<h2><a href="#o_flags" name="o_flags"></a> <a href="#o_flags"><code>o-flags</code></a>: record</h2>
+<h2><a href="#path_flags" name="path_flags"></a> <a href="#path_flags"><code>path-flags</code></a>: record</h2>
+<p>Flags determining the method of how paths are resolved.</p>
+<p>Size: 1, Alignment: 1</p>
+<h3>Record Fields</h3>
+<ul>
+<li>
+<p><a href="path_flags.symlink_follow" name="path_flags.symlink_follow"></a> <a href="#path_flags.symlink_follow"><code>symlink-follow</code></a>: </p>
+<p>As long as the resolved path corresponds to a symbolic link, it is expanded.
+Bit: 0</p>
+</li>
+</ul>
+<h2><a href="#open_flags" name="open_flags"></a> <a href="#open_flags"><code>open-flags</code></a>: record</h2>
 <p>Open flags used by <a href="#open_at"><code>open-at</code></a>.</p>
 <p>Size: 1, Alignment: 1</p>
 <h3>Record Fields</h3>
 <ul>
 <li>
-<p><a href="o_flags.create" name="o_flags.create"></a> <a href="#o_flags.create"><code>create</code></a>: </p>
+<p><a href="open_flags.create" name="open_flags.create"></a> <a href="#open_flags.create"><code>create</code></a>: </p>
 <p>Create file if it does not exist.
 Bit: 0</p>
 </li>
 <li>
-<p><a href="o_flags.directory" name="o_flags.directory"></a> <a href="#o_flags.directory"><code>directory</code></a>: </p>
+<p><a href="open_flags.directory" name="open_flags.directory"></a> <a href="#open_flags.directory"><code>directory</code></a>: </p>
 <p>Fail if not a directory.
 Bit: 1</p>
 </li>
 <li>
-<p><a href="o_flags.excl" name="o_flags.excl"></a> <a href="#o_flags.excl"><code>excl</code></a>: </p>
+<p><a href="open_flags.exclusive" name="open_flags.exclusive"></a> <a href="#open_flags.exclusive"><code>exclusive</code></a>: </p>
 <p>Fail if file already exists.
 Bit: 2</p>
 </li>
 <li>
-<p><a href="o_flags.trunc" name="o_flags.trunc"></a> <a href="#o_flags.trunc"><code>trunc</code></a>: </p>
+<p><a href="open_flags.truncate" name="open_flags.truncate"></a> <a href="#open_flags.truncate"><code>truncate</code></a>: </p>
 <p>Truncate file to size 0.
 Bit: 3</p>
 </li>
 </ul>
-<h2><a href="#mode" name="mode"></a> <a href="#mode"><code>mode</code></a>: record</h2>
+<h2><a href="#modes" name="modes"></a> <a href="#modes"><code>modes</code></a>: record</h2>
 <p>Permissions mode used by <a href="#open_at"><code>open-at</code></a>, <a href="#change_file_permissions_at"><code>change-file-permissions-at</code></a>, and
 similar.</p>
 <p>Size: 1, Alignment: 1</p>
 <h3>Record Fields</h3>
 <ul>
 <li>
-<p><a href="mode.readable" name="mode.readable"></a> <a href="#mode.readable"><code>readable</code></a>: </p>
+<p><a href="modes.readable" name="modes.readable"></a> <a href="#modes.readable"><code>readable</code></a>: </p>
 <p>True if the resource is considered readable by the containing
 filesystem.
 Bit: 0</p>
 </li>
 <li>
-<p><a href="mode.writeable" name="mode.writeable"></a> <a href="#mode.writeable"><code>writeable</code></a>: </p>
+<p><a href="modes.writeable" name="modes.writeable"></a> <a href="#modes.writeable"><code>writeable</code></a>: </p>
 <p>True if the resource is considered writeable by the containing
 filesystem.
 Bit: 1</p>
 </li>
 <li>
-<p><a href="mode.executable" name="mode.executable"></a> <a href="#mode.executable"><code>executable</code></a>: </p>
+<p><a href="modes.executable" name="modes.executable"></a> <a href="#modes.executable"><code>executable</code></a>: </p>
 <p>True if the resource is considered executable by the containing
 filesystem. This does not apply to directories.
 Bit: 2</p>
 </li>
 </ul>
-<h2><a href="#linkcount" name="linkcount"></a> <a href="#linkcount"><code>linkcount</code></a>: <code>u64</code></h2>
+<h2><a href="#link_count" name="link_count"></a> <a href="#link_count"><code>link-count</code></a>: <code>u64</code></h2>
 <p>Number of hard links to an inode.</p>
 <p>Size: 8, Alignment: 8</p>
 <h2><a href="#inode" name="inode"></a> <a href="#inode"><code>inode</code></a>: <code>u64</code></h2>
@@ -338,7 +366,7 @@ Bit: 2</p>
 <h2><a href="#filesize" name="filesize"></a> <a href="#filesize"><code>filesize</code></a>: <code>u64</code></h2>
 <p>File size or length of a region within a file.</p>
 <p>Size: 8, Alignment: 8</p>
-<h2><a href="#errno" name="errno"></a> <a href="#errno"><code>errno</code></a>: enum</h2>
+<h2><a href="#error_code" name="error_code"></a> <a href="#error_code"><code>error-code</code></a>: enum</h2>
 <p>Error codes returned by functions.
 Not all of these error codes are returned by the functions provided by this
 API; some are used in higher-level library layers, and others are provided
@@ -347,159 +375,155 @@ merely for alignment with POSIX.</p>
 <h3>Enum Cases</h3>
 <ul>
 <li>
-<p><a href="errno.access" name="errno.access"></a> <a href="#errno.access"><code>access</code></a></p>
+<p><a href="error_code.access" name="error_code.access"></a> <a href="#error_code.access"><code>access</code></a></p>
 <p>Permission denied.</p>
 </li>
 <li>
-<p><a href="errno.again" name="errno.again"></a> <a href="#errno.again"><code>again</code></a></p>
+<p><a href="error_code.would_block" name="error_code.would_block"></a> <a href="#error_code.would_block"><code>would-block</code></a></p>
 <p>Resource unavailable, or operation would block.</p>
 </li>
 <li>
-<p><a href="errno.already" name="errno.already"></a> <a href="#errno.already"><code>already</code></a></p>
+<p><a href="error_code.already" name="error_code.already"></a> <a href="#error_code.already"><code>already</code></a></p>
 <p>Connection already in progress.</p>
 </li>
 <li>
-<p><a href="errno.badf" name="errno.badf"></a> <a href="#errno.badf"><code>badf</code></a></p>
+<p><a href="error_code.bad_descriptor" name="error_code.bad_descriptor"></a> <a href="#error_code.bad_descriptor"><code>bad-descriptor</code></a></p>
 <p>Bad descriptor.</p>
 </li>
 <li>
-<p><a href="errno.busy" name="errno.busy"></a> <a href="#errno.busy"><code>busy</code></a></p>
+<p><a href="error_code.busy" name="error_code.busy"></a> <a href="#error_code.busy"><code>busy</code></a></p>
 <p>Device or resource busy.</p>
 </li>
 <li>
-<p><a href="errno.deadlk" name="errno.deadlk"></a> <a href="#errno.deadlk"><code>deadlk</code></a></p>
+<p><a href="error_code.deadlock" name="error_code.deadlock"></a> <a href="#error_code.deadlock"><code>deadlock</code></a></p>
 <p>Resource deadlock would occur.</p>
 </li>
 <li>
-<p><a href="errno.dquot" name="errno.dquot"></a> <a href="#errno.dquot"><code>dquot</code></a></p>
+<p><a href="error_code.quota" name="error_code.quota"></a> <a href="#error_code.quota"><code>quota</code></a></p>
 <p>Storage quota exceeded.</p>
 </li>
 <li>
-<p><a href="errno.exist" name="errno.exist"></a> <a href="#errno.exist"><code>exist</code></a></p>
+<p><a href="error_code.exist" name="error_code.exist"></a> <a href="#error_code.exist"><code>exist</code></a></p>
 <p>File exists.</p>
 </li>
 <li>
-<p><a href="errno.fbig" name="errno.fbig"></a> <a href="#errno.fbig"><code>fbig</code></a></p>
+<p><a href="error_code.file_too_large" name="error_code.file_too_large"></a> <a href="#error_code.file_too_large"><code>file-too-large</code></a></p>
 <p>File too large.</p>
 </li>
 <li>
-<p><a href="errno.ilseq" name="errno.ilseq"></a> <a href="#errno.ilseq"><code>ilseq</code></a></p>
+<p><a href="error_code.illegal_byte_sequence" name="error_code.illegal_byte_sequence"></a> <a href="#error_code.illegal_byte_sequence"><code>illegal-byte-sequence</code></a></p>
 <p>Illegal byte sequence.</p>
 </li>
 <li>
-<p><a href="errno.inprogress" name="errno.inprogress"></a> <a href="#errno.inprogress"><code>inprogress</code></a></p>
+<p><a href="error_code.in_progress" name="error_code.in_progress"></a> <a href="#error_code.in_progress"><code>in-progress</code></a></p>
 <p>Operation in progress.</p>
 </li>
 <li>
-<p><a href="errno.intr" name="errno.intr"></a> <a href="#errno.intr"><code>intr</code></a></p>
+<p><a href="error_code.interrupted" name="error_code.interrupted"></a> <a href="#error_code.interrupted"><code>interrupted</code></a></p>
 <p>Interrupted function.</p>
 </li>
 <li>
-<p><a href="errno.inval" name="errno.inval"></a> <a href="#errno.inval"><code>inval</code></a></p>
+<p><a href="error_code.invalid" name="error_code.invalid"></a> <a href="#error_code.invalid"><code>invalid</code></a></p>
 <p>Invalid argument.</p>
 </li>
 <li>
-<p><a href="errno.io" name="errno.io"></a> <a href="#errno.io"><code>io</code></a></p>
+<p><a href="error_code.io" name="error_code.io"></a> <a href="#error_code.io"><code>io</code></a></p>
 <p>I/O error.</p>
 </li>
 <li>
-<p><a href="errno.isdir" name="errno.isdir"></a> <a href="#errno.isdir"><code>isdir</code></a></p>
+<p><a href="error_code.is_directory" name="error_code.is_directory"></a> <a href="#error_code.is_directory"><code>is-directory</code></a></p>
 <p>Is a directory.</p>
 </li>
 <li>
-<p><a href="errno.loop" name="errno.loop"></a> <a href="#errno.loop"><code>loop</code></a></p>
+<p><a href="error_code.loop" name="error_code.loop"></a> <a href="#error_code.loop"><code>loop</code></a></p>
 <p>Too many levels of symbolic links.</p>
 </li>
 <li>
-<p><a href="errno.mlink" name="errno.mlink"></a> <a href="#errno.mlink"><code>mlink</code></a></p>
+<p><a href="error_code.too_many_links" name="error_code.too_many_links"></a> <a href="#error_code.too_many_links"><code>too-many-links</code></a></p>
 <p>Too many links.</p>
 </li>
 <li>
-<p><a href="errno.msgsize" name="errno.msgsize"></a> <a href="#errno.msgsize"><code>msgsize</code></a></p>
+<p><a href="error_code.message_size" name="error_code.message_size"></a> <a href="#error_code.message_size"><code>message-size</code></a></p>
 <p>Message too large.</p>
 </li>
 <li>
-<p><a href="errno.nametoolong" name="errno.nametoolong"></a> <a href="#errno.nametoolong"><code>nametoolong</code></a></p>
+<p><a href="error_code.name_too_long" name="error_code.name_too_long"></a> <a href="#error_code.name_too_long"><code>name-too-long</code></a></p>
 <p>Filename too long.</p>
 </li>
 <li>
-<p><a href="errno.nodev" name="errno.nodev"></a> <a href="#errno.nodev"><code>nodev</code></a></p>
+<p><a href="error_code.no_device" name="error_code.no_device"></a> <a href="#error_code.no_device"><code>no-device</code></a></p>
 <p>No such device.</p>
 </li>
 <li>
-<p><a href="errno.noent" name="errno.noent"></a> <a href="#errno.noent"><code>noent</code></a></p>
+<p><a href="error_code.no_entry" name="error_code.no_entry"></a> <a href="#error_code.no_entry"><code>no-entry</code></a></p>
 <p>No such file or directory.</p>
 </li>
 <li>
-<p><a href="errno.nolck" name="errno.nolck"></a> <a href="#errno.nolck"><code>nolck</code></a></p>
+<p><a href="error_code.no_lock" name="error_code.no_lock"></a> <a href="#error_code.no_lock"><code>no-lock</code></a></p>
 <p>No locks available.</p>
 </li>
 <li>
-<p><a href="errno.nomem" name="errno.nomem"></a> <a href="#errno.nomem"><code>nomem</code></a></p>
+<p><a href="error_code.insufficient_memory" name="error_code.insufficient_memory"></a> <a href="#error_code.insufficient_memory"><code>insufficient-memory</code></a></p>
 <p>Not enough space.</p>
 </li>
 <li>
-<p><a href="errno.nospc" name="errno.nospc"></a> <a href="#errno.nospc"><code>nospc</code></a></p>
+<p><a href="error_code.insufficient_space" name="error_code.insufficient_space"></a> <a href="#error_code.insufficient_space"><code>insufficient-space</code></a></p>
 <p>No space left on device.</p>
 </li>
 <li>
-<p><a href="errno.nosys" name="errno.nosys"></a> <a href="#errno.nosys"><code>nosys</code></a></p>
-<p>Function not supported.</p>
-</li>
-<li>
-<p><a href="errno.notdir" name="errno.notdir"></a> <a href="#errno.notdir"><code>notdir</code></a></p>
+<p><a href="error_code.not_directory" name="error_code.not_directory"></a> <a href="#error_code.not_directory"><code>not-directory</code></a></p>
 <p>Not a directory or a symbolic link to a directory.</p>
 </li>
 <li>
-<p><a href="errno.notempty" name="errno.notempty"></a> <a href="#errno.notempty"><code>notempty</code></a></p>
+<p><a href="error_code.not_empty" name="error_code.not_empty"></a> <a href="#error_code.not_empty"><code>not-empty</code></a></p>
 <p>Directory not empty.</p>
 </li>
 <li>
-<p><a href="errno.notrecoverable" name="errno.notrecoverable"></a> <a href="#errno.notrecoverable"><code>notrecoverable</code></a></p>
+<p><a href="error_code.not_recoverable" name="error_code.not_recoverable"></a> <a href="#error_code.not_recoverable"><code>not-recoverable</code></a></p>
 <p>State not recoverable.</p>
 </li>
 <li>
-<p><a href="errno.notsup" name="errno.notsup"></a> <a href="#errno.notsup"><code>notsup</code></a></p>
-<p>Not supported, or operation not supported on socket.</p>
+<p><a href="error_code.unsupported" name="error_code.unsupported"></a> <a href="#error_code.unsupported"><code>unsupported</code></a></p>
+<p>Not supported</p>
 </li>
 <li>
-<p><a href="errno.notty" name="errno.notty"></a> <a href="#errno.notty"><code>notty</code></a></p>
+<p><a href="error_code.no_tty" name="error_code.no_tty"></a> <a href="#error_code.no_tty"><code>no-tty</code></a></p>
 <p>Inappropriate I/O control operation.</p>
 </li>
 <li>
-<p><a href="errno.nxio" name="errno.nxio"></a> <a href="#errno.nxio"><code>nxio</code></a></p>
+<p><a href="error_code.no_such_device" name="error_code.no_such_device"></a> <a href="#error_code.no_such_device"><code>no-such-device</code></a></p>
 <p>No such device or address.</p>
 </li>
 <li>
-<p><a href="errno.overflow" name="errno.overflow"></a> <a href="#errno.overflow"><code>overflow</code></a></p>
+<p><a href="error_code.overflow" name="error_code.overflow"></a> <a href="#error_code.overflow"><code>overflow</code></a></p>
 <p>Value too large to be stored in data type.</p>
 </li>
 <li>
-<p><a href="errno.perm" name="errno.perm"></a> <a href="#errno.perm"><code>perm</code></a></p>
+<p><a href="error_code.not_permitted" name="error_code.not_permitted"></a> <a href="#error_code.not_permitted"><code>not-permitted</code></a></p>
 <p>Operation not permitted.</p>
 </li>
 <li>
-<p><a href="errno.pipe" name="errno.pipe"></a> <a href="#errno.pipe"><code>pipe</code></a></p>
+<p><a href="error_code.pipe" name="error_code.pipe"></a> <a href="#error_code.pipe"><code>pipe</code></a></p>
 <p>Broken pipe.</p>
 </li>
 <li>
-<p><a href="errno.rofs" name="errno.rofs"></a> <a href="#errno.rofs"><code>rofs</code></a></p>
+<p><a href="error_code.read_only" name="error_code.read_only"></a> <a href="#error_code.read_only"><code>read-only</code></a></p>
 <p>Read-only file system.</p>
 </li>
 <li>
-<p><a href="errno.spipe" name="errno.spipe"></a> <a href="#errno.spipe"><code>spipe</code></a></p>
+<p><a href="error_code.invalid_seek" name="error_code.invalid_seek"></a> <a href="#error_code.invalid_seek"><code>invalid-seek</code></a></p>
 <p>Invalid seek.</p>
 </li>
 <li>
-<p><a href="errno.txtbsy" name="errno.txtbsy"></a> <a href="#errno.txtbsy"><code>txtbsy</code></a></p>
+<p><a href="error_code.text_file_busy" name="error_code.text_file_busy"></a> <a href="#error_code.text_file_busy"><code>text-file-busy</code></a></p>
 <p>Text file busy.</p>
 </li>
 <li>
-<p><a href="errno.xdev" name="errno.xdev"></a> <a href="#errno.xdev"><code>xdev</code></a></p>
+<p><a href="error_code.cross_device" name="error_code.cross_device"></a> <a href="#error_code.cross_device"><code>cross-device</code></a></p>
 <p>Cross-device link.</p>
 </li>
 </ul>
-<h2><a href="#dir_entry_stream" name="dir_entry_stream"></a> <a href="#dir_entry_stream"><code>dir-entry-stream</code></a>: <code>u32</code></h2>
+<h2><a href="#directory_entry_stream" name="directory_entry_stream"></a> <a href="#directory_entry_stream"><code>directory-entry-stream</code></a>: <code>u32</code></h2>
 <p>A stream of directory entries.</p>
 <p>Size: 4, Alignment: 4</p>
 <h2><a href="#device" name="device"></a> <a href="#device"><code>device</code></a>: <code>u64</code></h2>
@@ -546,13 +570,13 @@ any of the other types specified.</p>
 <p>The descriptor refers to a socket.</p>
 </li>
 </ul>
-<h2><a href="#dir_entry" name="dir_entry"></a> <a href="#dir_entry"><code>dir-entry</code></a>: record</h2>
+<h2><a href="#directory_entry" name="directory_entry"></a> <a href="#directory_entry"><code>directory-entry</code></a>: record</h2>
 <p>A directory entry.</p>
 <p>Size: 32, Alignment: 8</p>
 <h3>Record Fields</h3>
 <ul>
 <li>
-<p><a href="dir_entry.ino" name="dir_entry.ino"></a> <a href="#dir_entry.ino"><code>ino</code></a>: option&lt;<a href="#inode"><a href="#inode"><code>inode</code></a></a>&gt;</p>
+<p><a href="directory_entry.inode" name="directory_entry.inode"></a> <a href="#directory_entry.inode"><a href="#inode"><code>inode</code></a></a>: option&lt;<a href="#inode"><a href="#inode"><code>inode</code></a></a>&gt;</p>
 <p>The serial number of the object referred to by this directory entry.
 May be none if the inode value is not known.</p>
 <p>When this is none, libc implementations might do an extra <a href="#stat_at"><code>stat-at</code></a>
@@ -560,11 +584,11 @@ call to retrieve the inode number to fill their <code>d_ino</code> fields, so
 implementations which can set this to a non-none value should do so.</p>
 </li>
 <li>
-<p><a href="dir_entry.type" name="dir_entry.type"></a> <a href="#dir_entry.type"><a href="#type"><code>type</code></a></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
+<p><a href="directory_entry.type" name="directory_entry.type"></a> <a href="#directory_entry.type"><code>type</code></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
 <p>The type of the file referred to by this directory entry.</p>
 </li>
 <li>
-<p><a href="dir_entry.name" name="dir_entry.name"></a> <a href="#dir_entry.name"><code>name</code></a>: <code>string</code></p>
+<p><a href="directory_entry.name" name="directory_entry.name"></a> <a href="#directory_entry.name"><code>name</code></a>: <code>string</code></p>
 <p>The name of the object.</p>
 </li>
 </ul>
@@ -585,16 +609,16 @@ Bit: 0</p>
 Bit: 1</p>
 </li>
 <li>
-<p><a href="descriptor_flags.nonblock" name="descriptor_flags.nonblock"></a> <a href="#descriptor_flags.nonblock"><code>nonblock</code></a>: </p>
+<p><a href="descriptor_flags.non_blocking" name="descriptor_flags.non_blocking"></a> <a href="#descriptor_flags.non_blocking"><code>non-blocking</code></a>: </p>
 <p>Requests non-blocking operation.</p>
 <p>When this flag is enabled, functions may return immediately with an
-<a href="#errno.again"><code>errno::again</code></a> error code in situations where they would otherwise
+<a href="#error_code.would_block"><code>error-code::would-block</code></a> error code in situations where they would otherwise
 block. However, this non-blocking behavior is not required.
 Implementations are permitted to ignore this flag and block.
 Bit: 2</p>
 </li>
 <li>
-<p><a href="descriptor_flags.sync" name="descriptor_flags.sync"></a> <a href="#descriptor_flags.sync"><a href="#sync"><code>sync</code></a></a>: </p>
+<p><a href="descriptor_flags.file_integrity_sync" name="descriptor_flags.file_integrity_sync"></a> <a href="#descriptor_flags.file_integrity_sync"><code>file-integrity-sync</code></a>: </p>
 <p>Request that writes be performed according to synchronized I/O file
 integrity completion. The data stored in the file and the file's
 metadata are synchronized.</p>
@@ -604,7 +628,7 @@ requirement.
 Bit: 3</p>
 </li>
 <li>
-<p><a href="descriptor_flags.dsync" name="descriptor_flags.dsync"></a> <a href="#descriptor_flags.dsync"><code>dsync</code></a>: </p>
+<p><a href="descriptor_flags.data_integrity_sync" name="descriptor_flags.data_integrity_sync"></a> <a href="#descriptor_flags.data_integrity_sync"><code>data-integrity-sync</code></a>: </p>
 <p>Request that writes be performed according to synchronized I/O data
 integrity completion. Only the data stored in the file is
 synchronized.</p>
@@ -614,7 +638,7 @@ requirement.
 Bit: 4</p>
 </li>
 <li>
-<p><a href="descriptor_flags.rsync" name="descriptor_flags.rsync"></a> <a href="#descriptor_flags.rsync"><code>rsync</code></a>: </p>
+<p><a href="descriptor_flags.requested_write_sync" name="descriptor_flags.requested_write_sync"></a> <a href="#descriptor_flags.requested_write_sync"><code>requested-write-sync</code></a>: </p>
 <p>Requests that reads be performed at the same level of integrety
 requested for writes.</p>
 <p>The precise semantics of this operation have not yet been defined for
@@ -628,7 +652,7 @@ Bit: 5</p>
 <p>When this flag is unset on a descriptor, operations using the
 descriptor which would create, rename, delete, modify the data or
 metadata of filesystem objects, or obtain another handle which
-would permit any of those, shall fail with <a href="#errno.rofs"><code>errno::rofs</code></a> if
+would permit any of those, shall fail with <a href="#error_code.read_only"><code>error-code::read-only</code></a> if
 they would otherwise succeed.</p>
 <p>This may only be set on directories.
 Bit: 6</p>
@@ -665,19 +689,19 @@ with the filesystem.</p>
 <h3>Record Fields</h3>
 <ul>
 <li>
-<p><a href="descriptor_stat.dev" name="descriptor_stat.dev"></a> <a href="#descriptor_stat.dev"><code>dev</code></a>: <a href="#device"><a href="#device"><code>device</code></a></a></p>
+<p><a href="descriptor_stat.device" name="descriptor_stat.device"></a> <a href="#descriptor_stat.device"><a href="#device"><code>device</code></a></a>: <a href="#device"><a href="#device"><code>device</code></a></a></p>
 <p>Device ID of device containing the file.</p>
 </li>
 <li>
-<p><a href="descriptor_stat.ino" name="descriptor_stat.ino"></a> <a href="#descriptor_stat.ino"><code>ino</code></a>: <a href="#inode"><a href="#inode"><code>inode</code></a></a></p>
+<p><a href="descriptor_stat.inode" name="descriptor_stat.inode"></a> <a href="#descriptor_stat.inode"><a href="#inode"><code>inode</code></a></a>: <a href="#inode"><a href="#inode"><code>inode</code></a></a></p>
 <p>File serial number.</p>
 </li>
 <li>
-<p><a href="descriptor_stat.type" name="descriptor_stat.type"></a> <a href="#descriptor_stat.type"><a href="#type"><code>type</code></a></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
+<p><a href="descriptor_stat.type" name="descriptor_stat.type"></a> <a href="#descriptor_stat.type"><code>type</code></a>: <a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a></p>
 <p>File type.</p>
 </li>
 <li>
-<p><a href="descriptor_stat.nlink" name="descriptor_stat.nlink"></a> <a href="#descriptor_stat.nlink"><code>nlink</code></a>: <a href="#linkcount"><a href="#linkcount"><code>linkcount</code></a></a></p>
+<p><a href="descriptor_stat.link_count" name="descriptor_stat.link_count"></a> <a href="#descriptor_stat.link_count"><a href="#link_count"><code>link-count</code></a></a>: <a href="#link_count"><a href="#link_count"><code>link-count</code></a></a></p>
 <p>Number of hard links to the file.</p>
 </li>
 <li>
@@ -686,27 +710,16 @@ with the filesystem.</p>
 in bytes of the pathname contained in the symbolic link.</p>
 </li>
 <li>
-<p><a href="descriptor_stat.atim" name="descriptor_stat.atim"></a> <a href="#descriptor_stat.atim"><code>atim</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p><a href="descriptor_stat.data_access_timestamp" name="descriptor_stat.data_access_timestamp"></a> <a href="#descriptor_stat.data_access_timestamp"><code>data-access-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
 <p>Last data access timestamp.</p>
 </li>
 <li>
-<p><a href="descriptor_stat.mtim" name="descriptor_stat.mtim"></a> <a href="#descriptor_stat.mtim"><code>mtim</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p><a href="descriptor_stat.data_modification_timestamp" name="descriptor_stat.data_modification_timestamp"></a> <a href="#descriptor_stat.data_modification_timestamp"><code>data-modification-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
 <p>Last data modification timestamp.</p>
 </li>
 <li>
-<p><a href="descriptor_stat.ctim" name="descriptor_stat.ctim"></a> <a href="#descriptor_stat.ctim"><code>ctim</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
+<p><a href="descriptor_stat.status_change_timestamp" name="descriptor_stat.status_change_timestamp"></a> <a href="#descriptor_stat.status_change_timestamp"><code>status-change-timestamp</code></a>: <a href="#datetime"><a href="#datetime"><code>datetime</code></a></a></p>
 <p>Last file status change timestamp.</p>
-</li>
-</ul>
-<h2><a href="#at_flags" name="at_flags"></a> <a href="#at_flags"><code>at-flags</code></a>: record</h2>
-<p>Flags determining the method of how paths are resolved.</p>
-<p>Size: 1, Alignment: 1</p>
-<h3>Record Fields</h3>
-<ul>
-<li>
-<p><a href="at_flags.symlink_follow" name="at_flags.symlink_follow"></a> <a href="#at_flags.symlink_follow"><code>symlink-follow</code></a>: </p>
-<p>As long as the resolved path corresponds to a symbolic link, it is expanded.
-Bit: 0</p>
 </li>
 </ul>
 <h2><a href="#advice" name="advice"></a> <a href="#advice"><code>advice</code></a>: enum</h2>
@@ -753,7 +766,7 @@ file and they do not interfere with each other.</p>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#read_via_stream.result0" name="read_via_stream.result0"></a> <code>result0</code>: result&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#read_via_stream.result0" name="read_via_stream.result0"></a> <code>result0</code>: result&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#write_via_stream" name="write_via_stream"></a> <a href="#write_via_stream"><code>write-via-stream</code></a></h4>
@@ -766,7 +779,7 @@ file and they do not interfere with each other.</p>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#write_via_stream.result0" name="write_via_stream.result0"></a> <code>result0</code>: result&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#write_via_stream.result0" name="write_via_stream.result0"></a> <code>result0</code>: result&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#append_via_stream" name="append_via_stream"></a> <a href="#append_via_stream"><code>append-via-stream</code></a></h4>
@@ -776,58 +789,59 @@ file and they do not interfere with each other.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#append_via_stream.this" name="append_via_stream.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a href="#append_via_stream.fd" name="append_via_stream.fd"></a> <code>fd</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#append_via_stream.result0" name="append_via_stream.result0"></a> <code>result0</code>: result&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#append_via_stream.result0" name="append_via_stream.result0"></a> <code>result0</code>: result&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#fadvise" name="fadvise"></a> <a href="#fadvise"><code>fadvise</code></a></h4>
+<h4><a href="#advise" name="advise"></a> <a href="#advise"><code>advise</code></a></h4>
 <p>Provide file advisory information on a descriptor.</p>
 <p>This is similar to <code>posix_fadvise</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#fadvise.this" name="fadvise.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#fadvise.offset" name="fadvise.offset"></a> <code>offset</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
-<li><a href="#fadvise.len" name="fadvise.len"></a> <code>len</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
-<li><a href="#fadvise.advice" name="fadvise.advice"></a> <a href="#advice"><code>advice</code></a>: <a href="#advice"><a href="#advice"><code>advice</code></a></a></li>
+<li><a href="#advise.this" name="advise.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a href="#advise.offset" name="advise.offset"></a> <code>offset</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a href="#advise.length" name="advise.length"></a> <code>length</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a href="#advise.advice" name="advise.advice"></a> <a href="#advice"><code>advice</code></a>: <a href="#advice"><a href="#advice"><code>advice</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#fadvise.result0" name="fadvise.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#advise.result0" name="advise.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#datasync" name="datasync"></a> <a href="#datasync"><code>datasync</code></a></h4>
+<h4><a href="#sync_data" name="sync_data"></a> <a href="#sync_data"><code>sync-data</code></a></h4>
 <p>Synchronize the data of a file to disk.</p>
 <p>This function succeeds with no effect if the file descriptor is not
 opened for writing.</p>
 <p>Note: This is similar to <code>fdatasync</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#datasync.this" name="datasync.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a href="#sync_data.this" name="sync_data.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#datasync.result0" name="datasync.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#sync_data.result0" name="sync_data.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#flags" name="flags"></a> <a href="#flags"><code>flags</code></a></h4>
+<h4><a href="#get_flags" name="get_flags"></a> <a href="#get_flags"><code>get-flags</code></a></h4>
 <p>Get flags associated with a descriptor.</p>
 <p>Note: This returns similar flags to <code>fcntl(fd, F_GETFL)</code> in POSIX.</p>
 <p>Note: This returns the value that was the <code>fs_flags</code> value returned
 from <code>fdstat_get</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#flags.this" name="flags.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a href="#get_flags.this" name="get_flags.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#flags.result0" name="flags.result0"></a> <code>result0</code>: result&lt;<a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#get_flags.result0" name="get_flags.result0"></a> <code>result0</code>: result&lt;<a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#type" name="type"></a> <a href="#type"><code>type</code></a></h4>
+<h4><a href="#get_type" name="get_type"></a> <a href="#get_type"><code>get-type</code></a></h4>
 <p>Get the dynamic type of a descriptor.</p>
-<p>Note: This returns the same value as the <a href="#type"><code>type</code></a> field of the <code>fd-stat</code>
+<p>Note: This returns the same value as the <code>type</code> field of the <code>fd-stat</code>
 returned by <a href="#stat"><code>stat</code></a>, <a href="#stat_at"><code>stat-at</code></a> and similar.</p>
 <p>Note: This returns similar flags to the <code>st_mode &amp; S_IFMT</code> value provided
 by <code>fstat</code> in POSIX.</p>
@@ -835,26 +849,26 @@ by <code>fstat</code> in POSIX.</p>
 from <code>fdstat_get</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#type.this" name="type.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a href="#get_type.this" name="get_type.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#type.result0" name="type.result0"></a> <code>result0</code>: result&lt;<a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#get_type.result0" name="get_type.result0"></a> <code>result0</code>: result&lt;<a href="#descriptor_type"><a href="#descriptor_type"><code>descriptor-type</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#set_flags" name="set_flags"></a> <a href="#set_flags"><code>set-flags</code></a></h4>
 <p>Set status flags associated with a descriptor.</p>
-<p>This function may only change the <code>nonblock</code> flag.</p>
+<p>This function may only change the <code>non-blocking</code> flag.</p>
 <p>Note: This is similar to <code>fcntl(fd, F_SETFL, flags)</code> in POSIX.</p>
 <p>Note: This was called <code>fd_fdstat_set_flags</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#set_flags.this" name="set_flags.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#set_flags.flags" name="set_flags.flags"></a> <a href="#flags"><code>flags</code></a>: <a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a></li>
+<li><a href="#set_flags.flags" name="set_flags.flags"></a> <code>flags</code>: <a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#set_flags.result0" name="set_flags.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#set_flags.result0" name="set_flags.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#set_size" name="set_size"></a> <a href="#set_size"><code>set-size</code></a></h4>
@@ -868,7 +882,7 @@ extra bytes are filled with zeros.</p>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#set_size.result0" name="set_size.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#set_size.result0" name="set_size.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#set_times" name="set_times"></a> <a href="#set_times"><code>set-times</code></a></h4>
@@ -878,51 +892,51 @@ extra bytes are filled with zeros.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#set_times.this" name="set_times.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#set_times.atim" name="set_times.atim"></a> <code>atim</code>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
-<li><a href="#set_times.mtim" name="set_times.mtim"></a> <code>mtim</code>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
+<li><a href="#set_times.data_access_timestamp" name="set_times.data_access_timestamp"></a> <code>data-access-timestamp</code>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
+<li><a href="#set_times.data_modification_timestamp" name="set_times.data_modification_timestamp"></a> <code>data-modification-timestamp</code>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#set_times.result0" name="set_times.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#set_times.result0" name="set_times.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#pread" name="pread"></a> <a href="#pread"><code>pread</code></a></h4>
+<h4><a href="#read" name="read"></a> <a href="#read"><code>read</code></a></h4>
 <p>Read from a descriptor, without using and updating the descriptor's offset.</p>
 <p>This function returns a list of bytes containing the data that was
 read, along with a bool which, when true, indicates that the end of the
-file was reached. The returned list will contain up to <code>len</code> bytes; it
+file was reached. The returned list will contain up to <code>length</code> bytes; it
 may return fewer than requested, if the end of the file is reached or
 if the I/O operation is interrupted.</p>
-<p>Note: This is similar to <a href="#pread"><code>pread</code></a> in POSIX.</p>
+<p>Note: This is similar to <code>pread</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#pread.this" name="pread.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#pread.len" name="pread.len"></a> <code>len</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
-<li><a href="#pread.offset" name="pread.offset"></a> <code>offset</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a href="#read.this" name="read.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a href="#read.length" name="read.length"></a> <code>length</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a href="#read.offset" name="read.offset"></a> <code>offset</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#pread.result0" name="pread.result0"></a> <code>result0</code>: result&lt;(list&lt;<code>u8</code>&gt;, <code>bool</code>), <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#read.result0" name="read.result0"></a> <code>result0</code>: result&lt;(list&lt;<code>u8</code>&gt;, <code>bool</code>), <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#pwrite" name="pwrite"></a> <a href="#pwrite"><code>pwrite</code></a></h4>
+<h4><a href="#write" name="write"></a> <a href="#write"><code>write</code></a></h4>
 <p>Write to a descriptor, without using and updating the descriptor's offset.</p>
 <p>It is valid to write past the end of a file; the file is extended to the
 extent of the write, with bytes between the previous end and the start of
 the write set to zero.</p>
-<p>Note: This is similar to <a href="#pwrite"><code>pwrite</code></a> in POSIX.</p>
+<p>Note: This is similar to <code>pwrite</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#pwrite.this" name="pwrite.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#pwrite.buf" name="pwrite.buf"></a> <code>buf</code>: list&lt;<code>u8</code>&gt;</li>
-<li><a href="#pwrite.offset" name="pwrite.offset"></a> <code>offset</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
+<li><a href="#write.this" name="write.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a href="#write.buffer" name="write.buffer"></a> <code>buffer</code>: list&lt;<code>u8</code>&gt;</li>
+<li><a href="#write.offset" name="write.offset"></a> <code>offset</code>: <a href="#filesize"><a href="#filesize"><code>filesize</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#pwrite.result0" name="pwrite.result0"></a> <code>result0</code>: result&lt;<a href="#filesize"><a href="#filesize"><code>filesize</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#write.result0" name="write.result0"></a> <code>result0</code>: result&lt;<a href="#filesize"><a href="#filesize"><code>filesize</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#readdir" name="readdir"></a> <a href="#readdir"><code>readdir</code></a></h4>
+<h4><a href="#read_directory" name="read_directory"></a> <a href="#read_directory"><code>read-directory</code></a></h4>
 <p>Read directory entries from a directory.</p>
 <p>On filesystems where directories contain entries referring to themselves
 and their parents, often named <code>.</code> and <code>..</code> respectively, these entries
@@ -932,11 +946,11 @@ directory. Multiple streams may be active on the same directory, and they
 do not interfere with each other.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#readdir.this" name="readdir.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+<li><a href="#read_directory.this" name="read_directory.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#readdir.result0" name="readdir.result0"></a> <code>result0</code>: result&lt;<a href="#dir_entry_stream"><a href="#dir_entry_stream"><code>dir-entry-stream</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#read_directory.result0" name="read_directory.result0"></a> <code>result0</code>: result&lt;<a href="#directory_entry_stream"><a href="#directory_entry_stream"><code>directory-entry-stream</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#sync" name="sync"></a> <a href="#sync"><code>sync</code></a></h4>
@@ -950,7 +964,7 @@ opened for writing.</p>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#sync.result0" name="sync.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#sync.result0" name="sync.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#create_directory_at" name="create_directory_at"></a> <a href="#create_directory_at"><code>create-directory-at</code></a></h4>
@@ -963,7 +977,7 @@ opened for writing.</p>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#create_directory_at.result0" name="create_directory_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#create_directory_at.result0" name="create_directory_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#stat" name="stat"></a> <a href="#stat"><code>stat</code></a></h4>
@@ -976,7 +990,7 @@ opened for writing.</p>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#stat.result0" name="stat.result0"></a> <code>result0</code>: result&lt;<a href="#descriptor_stat"><a href="#descriptor_stat"><code>descriptor-stat</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#stat.result0" name="stat.result0"></a> <code>result0</code>: result&lt;<a href="#descriptor_stat"><a href="#descriptor_stat"><code>descriptor-stat</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#stat_at" name="stat_at"></a> <a href="#stat_at"><code>stat-at</code></a></h4>
@@ -986,12 +1000,12 @@ opened for writing.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#stat_at.this" name="stat_at.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#stat_at.at_flags" name="stat_at.at_flags"></a> <a href="#at_flags"><code>at-flags</code></a>: <a href="#at_flags"><a href="#at_flags"><code>at-flags</code></a></a></li>
+<li><a href="#stat_at.path_flags" name="stat_at.path_flags"></a> <a href="#path_flags"><code>path-flags</code></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
 <li><a href="#stat_at.path" name="stat_at.path"></a> <code>path</code>: <code>string</code></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#stat_at.result0" name="stat_at.result0"></a> <code>result0</code>: result&lt;<a href="#descriptor_stat"><a href="#descriptor_stat"><code>descriptor-stat</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#stat_at.result0" name="stat_at.result0"></a> <code>result0</code>: result&lt;<a href="#descriptor_stat"><a href="#descriptor_stat"><code>descriptor-stat</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#set_times_at" name="set_times_at"></a> <a href="#set_times_at"><code>set-times-at</code></a></h4>
@@ -1001,14 +1015,14 @@ opened for writing.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#set_times_at.this" name="set_times_at.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#set_times_at.at_flags" name="set_times_at.at_flags"></a> <a href="#at_flags"><code>at-flags</code></a>: <a href="#at_flags"><a href="#at_flags"><code>at-flags</code></a></a></li>
+<li><a href="#set_times_at.path_flags" name="set_times_at.path_flags"></a> <a href="#path_flags"><code>path-flags</code></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
 <li><a href="#set_times_at.path" name="set_times_at.path"></a> <code>path</code>: <code>string</code></li>
-<li><a href="#set_times_at.atim" name="set_times_at.atim"></a> <code>atim</code>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
-<li><a href="#set_times_at.mtim" name="set_times_at.mtim"></a> <code>mtim</code>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
+<li><a href="#set_times_at.data_access_timestamp" name="set_times_at.data_access_timestamp"></a> <code>data-access-timestamp</code>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
+<li><a href="#set_times_at.data_modification_timestamp" name="set_times_at.data_modification_timestamp"></a> <code>data-modification-timestamp</code>: <a href="#new_timestamp"><a href="#new_timestamp"><code>new-timestamp</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#set_times_at.result0" name="set_times_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#set_times_at.result0" name="set_times_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#link_at" name="link_at"></a> <a href="#link_at"><code>link-at</code></a></h4>
@@ -1017,14 +1031,14 @@ opened for writing.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#link_at.this" name="link_at.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#link_at.old_at_flags" name="link_at.old_at_flags"></a> <code>old-at-flags</code>: <a href="#at_flags"><a href="#at_flags"><code>at-flags</code></a></a></li>
+<li><a href="#link_at.old_path_flags" name="link_at.old_path_flags"></a> <code>old-path-flags</code>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
 <li><a href="#link_at.old_path" name="link_at.old_path"></a> <code>old-path</code>: <code>string</code></li>
 <li><a href="#link_at.new_descriptor" name="link_at.new_descriptor"></a> <code>new-descriptor</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 <li><a href="#link_at.new_path" name="link_at.new_path"></a> <code>new-path</code>: <code>string</code></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#link_at.result0" name="link_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#link_at.result0" name="link_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#open_at" name="open_at"></a> <a href="#open_at"><code>open-at</code></a></h4>
@@ -1034,32 +1048,32 @@ descriptor not currently open/ it is randomized to prevent applications
 from depending on making assumptions about indexes, since this is
 error-prone in multi-threaded contexts. The returned descriptor is
 guaranteed to be less than 2**31.</p>
-<p>If <a href="#flags"><code>flags</code></a> contains <a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a>, and the base
+<p>If <code>flags</code> contains <a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a>, and the base
 descriptor doesn't have <a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a> set,
-<a href="#open_at"><code>open-at</code></a> fails with <a href="#errno.rofs"><code>errno::rofs</code></a>.</p>
-<p>If <a href="#flags"><code>flags</code></a> contains <a href="#write"><code>write</code></a> or <code>mutate-directory</code>, or <a href="#o_flags"><code>o-flags</code></a> contains
-<code>trunc</code> or <code>create</code>, and the base descriptor doesn't have
+<a href="#open_at"><code>open-at</code></a> fails with <a href="#error_code.read_only"><code>error-code::read-only</code></a>.</p>
+<p>If <code>flags</code> contains <a href="#write"><code>write</code></a> or <code>mutate-directory</code>, or <a href="#open_flags"><code>open-flags</code></a>
+contains <code>truncate</code> or <code>create</code>, and the base descriptor doesn't have
 <a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a> set, <a href="#open_at"><code>open-at</code></a> fails with
-<a href="#errno.rofs"><code>errno::rofs</code></a>.</p>
+<a href="#error_code.read_only"><code>error-code::read-only</code></a>.</p>
 <p>Note: This is similar to <code>openat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#open_at.this" name="open_at.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#open_at.at_flags" name="open_at.at_flags"></a> <a href="#at_flags"><code>at-flags</code></a>: <a href="#at_flags"><a href="#at_flags"><code>at-flags</code></a></a></li>
+<li><a href="#open_at.path_flags" name="open_at.path_flags"></a> <a href="#path_flags"><code>path-flags</code></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
 <li><a href="#open_at.path" name="open_at.path"></a> <code>path</code>: <code>string</code></li>
-<li><a href="#open_at.o_flags" name="open_at.o_flags"></a> <a href="#o_flags"><code>o-flags</code></a>: <a href="#o_flags"><a href="#o_flags"><code>o-flags</code></a></a></li>
-<li><a href="#open_at.flags" name="open_at.flags"></a> <a href="#flags"><code>flags</code></a>: <a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a></li>
-<li><a href="#open_at.mode" name="open_at.mode"></a> <a href="#mode"><code>mode</code></a>: <a href="#mode"><a href="#mode"><code>mode</code></a></a></li>
+<li><a href="#open_at.open_flags" name="open_at.open_flags"></a> <a href="#open_flags"><code>open-flags</code></a>: <a href="#open_flags"><a href="#open_flags"><code>open-flags</code></a></a></li>
+<li><a href="#open_at.flags" name="open_at.flags"></a> <code>flags</code>: <a href="#descriptor_flags"><a href="#descriptor_flags"><code>descriptor-flags</code></a></a></li>
+<li><a href="#open_at.modes" name="open_at.modes"></a> <a href="#modes"><code>modes</code></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#open_at.result0" name="open_at.result0"></a> <code>result0</code>: result&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#open_at.result0" name="open_at.result0"></a> <code>result0</code>: result&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#readlink_at" name="readlink_at"></a> <a href="#readlink_at"><code>readlink-at</code></a></h4>
 <p>Read the contents of a symbolic link.</p>
 <p>If the contents contain an absolute or rooted path in the underlying
-filesystem, this function fails with <a href="#errno.perm"><code>errno::perm</code></a>.</p>
+filesystem, this function fails with <a href="#error_code.not_permitted"><code>error-code::not-permitted</code></a>.</p>
 <p>Note: This is similar to <code>readlinkat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
@@ -1068,12 +1082,12 @@ filesystem, this function fails with <a href="#errno.perm"><code>errno::perm</co
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#readlink_at.result0" name="readlink_at.result0"></a> <code>result0</code>: result&lt;<code>string</code>, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#readlink_at.result0" name="readlink_at.result0"></a> <code>result0</code>: result&lt;<code>string</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#remove_directory_at" name="remove_directory_at"></a> <a href="#remove_directory_at"><code>remove-directory-at</code></a></h4>
 <p>Remove a directory.</p>
-<p>Return <a href="#errno.notempty"><code>errno::notempty</code></a> if the directory is not empty.</p>
+<p>Return <a href="#error_code.not_empty"><code>error-code::not-empty</code></a> if the directory is not empty.</p>
 <p>Note: This is similar to <code>unlinkat(fd, path, AT_REMOVEDIR)</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
@@ -1082,7 +1096,7 @@ filesystem, this function fails with <a href="#errno.perm"><code>errno::perm</co
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#remove_directory_at.result0" name="remove_directory_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#remove_directory_at.result0" name="remove_directory_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#rename_at" name="rename_at"></a> <a href="#rename_at"><code>rename-at</code></a></h4>
@@ -1097,12 +1111,12 @@ filesystem, this function fails with <a href="#errno.perm"><code>errno::perm</co
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#rename_at.result0" name="rename_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#rename_at.result0" name="rename_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#symlink_at" name="symlink_at"></a> <a href="#symlink_at"><code>symlink-at</code></a></h4>
 <p>Create a symbolic link (also known as a &quot;symlink&quot;).</p>
-<p>If <code>old-path</code> starts with <code>/</code>, the function fails with <a href="#errno.perm"><code>errno::perm</code></a>.</p>
+<p>If <code>old-path</code> starts with <code>/</code>, the function fails with <a href="#error_code.not_permitted"><code>error-code::not-permitted</code></a>.</p>
 <p>Note: This is similar to <code>symlinkat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
@@ -1112,12 +1126,12 @@ filesystem, this function fails with <a href="#errno.perm"><code>errno::perm</co
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#symlink_at.result0" name="symlink_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#symlink_at.result0" name="symlink_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#unlink_file_at" name="unlink_file_at"></a> <a href="#unlink_file_at"><code>unlink-file-at</code></a></h4>
 <p>Unlink a filesystem object that is not a directory.</p>
-<p>Return <a href="#errno.isdir"><code>errno::isdir</code></a> if the path refers to a directory.
+<p>Return <a href="#error_code.is_directory"><code>error-code::is-directory</code></a> if the path refers to a directory.
 Note: This is similar to <code>unlinkat(fd, path, 0)</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
@@ -1126,7 +1140,7 @@ Note: This is similar to <code>unlinkat(fd, path, 0)</code> in POSIX.</p>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#unlink_file_at.result0" name="unlink_file_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#unlink_file_at.result0" name="unlink_file_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#change_file_permissions_at" name="change_file_permissions_at"></a> <a href="#change_file_permissions_at"><code>change-file-permissions-at</code></a></h4>
@@ -1137,13 +1151,13 @@ filesystem-specific.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#change_file_permissions_at.this" name="change_file_permissions_at.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#change_file_permissions_at.at_flags" name="change_file_permissions_at.at_flags"></a> <a href="#at_flags"><code>at-flags</code></a>: <a href="#at_flags"><a href="#at_flags"><code>at-flags</code></a></a></li>
+<li><a href="#change_file_permissions_at.path_flags" name="change_file_permissions_at.path_flags"></a> <a href="#path_flags"><code>path-flags</code></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
 <li><a href="#change_file_permissions_at.path" name="change_file_permissions_at.path"></a> <code>path</code>: <code>string</code></li>
-<li><a href="#change_file_permissions_at.mode" name="change_file_permissions_at.mode"></a> <a href="#mode"><code>mode</code></a>: <a href="#mode"><a href="#mode"><code>mode</code></a></a></li>
+<li><a href="#change_file_permissions_at.modes" name="change_file_permissions_at.modes"></a> <a href="#modes"><code>modes</code></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#change_file_permissions_at.result0" name="change_file_permissions_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#change_file_permissions_at.result0" name="change_file_permissions_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#change_directory_permissions_at" name="change_directory_permissions_at"></a> <a href="#change_directory_permissions_at"><code>change-directory-permissions-at</code></a></h4>
@@ -1157,13 +1171,13 @@ flag. <a href="#read"><code>read</code></a> on a directory implies readability a
 <h5>Params</h5>
 <ul>
 <li><a href="#change_directory_permissions_at.this" name="change_directory_permissions_at.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#change_directory_permissions_at.at_flags" name="change_directory_permissions_at.at_flags"></a> <a href="#at_flags"><code>at-flags</code></a>: <a href="#at_flags"><a href="#at_flags"><code>at-flags</code></a></a></li>
+<li><a href="#change_directory_permissions_at.path_flags" name="change_directory_permissions_at.path_flags"></a> <a href="#path_flags"><code>path-flags</code></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
 <li><a href="#change_directory_permissions_at.path" name="change_directory_permissions_at.path"></a> <code>path</code>: <code>string</code></li>
-<li><a href="#change_directory_permissions_at.mode" name="change_directory_permissions_at.mode"></a> <a href="#mode"><code>mode</code></a>: <a href="#mode"><a href="#mode"><code>mode</code></a></a></li>
+<li><a href="#change_directory_permissions_at.modes" name="change_directory_permissions_at.modes"></a> <a href="#modes"><code>modes</code></a>: <a href="#modes"><a href="#modes"><code>modes</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#change_directory_permissions_at.result0" name="change_directory_permissions_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#change_directory_permissions_at.result0" name="change_directory_permissions_at.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#lock_shared" name="lock_shared"></a> <a href="#lock_shared"><code>lock-shared</code></a></h4>
@@ -1178,7 +1192,7 @@ by other programs that don't hold the lock.</p>
 non-WASI programs.</p>
 <p>This function blocks until the lock can be acquired.</p>
 <p>Not all filesystems support locking; on filesystems which don't support
-locking, this function returns <a href="#errno.notsup"><code>errno::notsup</code></a>.</p>
+locking, this function returns <a href="#error_code.unsupported"><code>error-code::unsupported</code></a>.</p>
 <p>Note: This is similar to <code>flock(fd, LOCK_SH)</code> in Unix.</p>
 <h5>Params</h5>
 <ul>
@@ -1186,7 +1200,7 @@ locking, this function returns <a href="#errno.notsup"><code>errno::notsup</code
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#lock_shared.result0" name="lock_shared.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#lock_shared.result0" name="lock_shared.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#lock_exclusive" name="lock_exclusive"></a> <a href="#lock_exclusive"><code>lock-exclusive</code></a></h4>
@@ -1203,7 +1217,7 @@ is not opened for writing. It is unspecified how exclusive locks interact
 with locks acquired by non-WASI programs.</p>
 <p>This function blocks until the lock can be acquired.</p>
 <p>Not all filesystems support locking; on filesystems which don't support
-locking, this function returns <a href="#errno.notsup"><code>errno::notsup</code></a>.</p>
+locking, this function returns <a href="#error_code.unsupported"><code>error-code::unsupported</code></a>.</p>
 <p>Note: This is similar to <code>flock(fd, LOCK_EX)</code> in Unix.</p>
 <h5>Params</h5>
 <ul>
@@ -1211,7 +1225,7 @@ locking, this function returns <a href="#errno.notsup"><code>errno::notsup</code
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#lock_exclusive.result0" name="lock_exclusive.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#lock_exclusive.result0" name="lock_exclusive.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#try_lock_shared" name="try_lock_shared"></a> <a href="#try_lock_shared"><code>try-lock-shared</code></a></h4>
@@ -1224,9 +1238,9 @@ to a shared lock. If it has a shared lock, this function has no effect.</p>
 by other programs that don't hold the lock.</p>
 <p>It is unspecified how shared locks interact with locks acquired by
 non-WASI programs.</p>
-<p>This function returns <a href="#errno.again"><code>errno::again</code></a> if the lock cannot be acquired.</p>
+<p>This function returns <a href="#error_code.would_block"><code>error-code::would-block</code></a> if the lock cannot be acquired.</p>
 <p>Not all filesystems support locking; on filesystems which don't support
-locking, this function returns <a href="#errno.notsup"><code>errno::notsup</code></a>.</p>
+locking, this function returns <a href="#error_code.unsupported"><code>error-code::unsupported</code></a>.</p>
 <p>Note: This is similar to <code>flock(fd, LOCK_SH | LOCK_NB)</code> in Unix.</p>
 <h5>Params</h5>
 <ul>
@@ -1234,7 +1248,7 @@ locking, this function returns <a href="#errno.notsup"><code>errno::notsup</code
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#try_lock_shared.result0" name="try_lock_shared.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#try_lock_shared.result0" name="try_lock_shared.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#try_lock_exclusive" name="try_lock_exclusive"></a> <a href="#try_lock_exclusive"><code>try-lock-exclusive</code></a></h4>
@@ -1249,9 +1263,9 @@ by other programs that don't hold the lock.</p>
 <p>It is unspecified whether this function succeeds if the file descriptor
 is not opened for writing. It is unspecified how exclusive locks interact
 with locks acquired by non-WASI programs.</p>
-<p>This function returns <a href="#errno.again"><code>errno::again</code></a> if the lock cannot be acquired.</p>
+<p>This function returns <a href="#error_code.would_block"><code>error-code::would-block</code></a> if the lock cannot be acquired.</p>
 <p>Not all filesystems support locking; on filesystems which don't support
-locking, this function returns <a href="#errno.notsup"><code>errno::notsup</code></a>.</p>
+locking, this function returns <a href="#error_code.unsupported"><code>error-code::unsupported</code></a>.</p>
 <p>Note: This is similar to <code>flock(fd, LOCK_EX | LOCK_NB)</code> in Unix.</p>
 <h5>Params</h5>
 <ul>
@@ -1259,7 +1273,7 @@ locking, this function returns <a href="#errno.notsup"><code>errno::notsup</code
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#try_lock_exclusive.result0" name="try_lock_exclusive.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#try_lock_exclusive.result0" name="try_lock_exclusive.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#unlock" name="unlock"></a> <a href="#unlock"><code>unlock</code></a></h4>
@@ -1271,7 +1285,7 @@ locking, this function returns <a href="#errno.notsup"><code>errno::notsup</code
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#unlock.result0" name="unlock.result0"></a> <code>result0</code>: result&lt;_, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#unlock.result0" name="unlock.result0"></a> <code>result0</code>: result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#drop_descriptor" name="drop_descriptor"></a> <a href="#drop_descriptor"><code>drop-descriptor</code></a></h4>
@@ -1282,21 +1296,21 @@ be used.</p>
 <li><a href="#drop_descriptor.this" name="drop_descriptor.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 </ul>
 <hr />
-<h4><a href="#read_dir_entry" name="read_dir_entry"></a> <a href="#read_dir_entry"><code>read-dir-entry</code></a></h4>
-<p>Read a single directory entry from a <a href="#dir_entry_stream"><code>dir-entry-stream</code></a>.</p>
+<h4><a href="#read_directory_entry" name="read_directory_entry"></a> <a href="#read_directory_entry"><code>read-directory-entry</code></a></h4>
+<p>Read a single directory entry from a <a href="#directory_entry_stream"><code>directory-entry-stream</code></a>.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#read_dir_entry.this" name="read_dir_entry.this"></a> <code>this</code>: <a href="#dir_entry_stream"><a href="#dir_entry_stream"><code>dir-entry-stream</code></a></a></li>
+<li><a href="#read_directory_entry.this" name="read_directory_entry.this"></a> <code>this</code>: <a href="#directory_entry_stream"><a href="#directory_entry_stream"><code>directory-entry-stream</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#read_dir_entry.result0" name="read_dir_entry.result0"></a> <code>result0</code>: result&lt;option&lt;<a href="#dir_entry"><a href="#dir_entry"><code>dir-entry</code></a></a>&gt;, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#read_directory_entry.result0" name="read_directory_entry.result0"></a> <code>result0</code>: result&lt;option&lt;<a href="#directory_entry"><a href="#directory_entry"><code>directory-entry</code></a></a>&gt;, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#drop_dir_entry_stream" name="drop_dir_entry_stream"></a> <a href="#drop_dir_entry_stream"><code>drop-dir-entry-stream</code></a></h4>
-<p>Dispose of the specified <a href="#dir_entry_stream"><code>dir-entry-stream</code></a>, after which it may no longer
+<h4><a href="#drop_directory_entry_stream" name="drop_directory_entry_stream"></a> <a href="#drop_directory_entry_stream"><code>drop-directory-entry-stream</code></a></h4>
+<p>Dispose of the specified <a href="#directory_entry_stream"><code>directory-entry-stream</code></a>, after which it may no longer
 be used.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#drop_dir_entry_stream.this" name="drop_dir_entry_stream.this"></a> <code>this</code>: <a href="#dir_entry_stream"><a href="#dir_entry_stream"><code>dir-entry-stream</code></a></a></li>
+<li><a href="#drop_directory_entry_stream.this" name="drop_directory_entry_stream.this"></a> <code>this</code>: <a href="#directory_entry_stream"><a href="#directory_entry_stream"><code>directory-entry-stream</code></a></a></li>
 </ul>

--- a/wasi-filesystem.html
+++ b/wasi-filesystem.html
@@ -55,12 +55,6 @@ doesn't provide any additional information.</p>
 types.</p>
 <p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
 scaffolding until component-model's async features are ready.</p>
-<p><a href="#output_stream"><code>output-stream</code></a>s are <em>non-blocking</em> to the extent practical on
-underlying platforms. Except where specified otherwise, I/O operations also
-always return promptly, after the number of bytes that can be written
-promptly, which could even be zero. To wait for the stream to be ready to
-accept data, the <a href="#subscribe_to_output_stream"><code>subscribe-to-output-stream</code></a> function to obtain a
-<a href="#pollable"><code>pollable</code></a> which can be polled for using <code>wasi_poll</code>.</p>
 <p>And at present, it is a <code>u32</code> instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.</p>
 <p>Size: 4, Alignment: 4</p>
@@ -69,12 +63,6 @@ the wit-bindgen implementation of handles and resources is ready.</p>
 types.</p>
 <p>This conceptually represents a <code>stream&lt;u8, _&gt;</code>. It's temporary
 scaffolding until component-model's async features are ready.</p>
-<p><a href="#input_stream"><code>input-stream</code></a>s are <em>non-blocking</em> to the extent practical on underlying
-platforms. I/O operations always return promptly; if fewer bytes are
-promptly available than requested, they return the number of bytes promptly
-available, which could even be zero. To wait for data to be available,
-use the <a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a> function to obtain a <a href="#pollable"><code>pollable</code></a> which
-can be polled for using <code>wasi_poll</code>.</p>
 <p>And at present, it is a <code>u32</code> instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.</p>
 <p>Size: 4, Alignment: 4</p>
@@ -177,8 +165,6 @@ that were written; it may be less than <code>len</code>.</p>
 <p>Read from one stream and write to another.</p>
 <p>This function returns the number of bytes transferred; it may be less
 than <code>len</code>.</p>
-<p>Unlike other I/O functions, this function blocks until all the data
-read from the input stream has been written to the output stream.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#splice.this" name="splice.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
@@ -195,9 +181,6 @@ read from the input stream has been written to the output stream.</p>
 <p>This function repeatedly reads from the input stream and writes
 the data to the output stream, until the end of the input stream
 is reached, or an error is encountered.</p>
-<p>Unlike other I/O functions, this function blocks until the end
-of the input stream is seen and all the data has been written to
-the output stream.</p>
 <p>This function returns the number of bytes transferred.</p>
 <h5>Params</h5>
 <ul>

--- a/wasi-filesystem.html
+++ b/wasi-filesystem.html
@@ -1102,6 +1102,7 @@ filesystem, this function fails with <a href="#errno.perm"><code>errno::perm</co
 <hr />
 <h4><a href="#symlink_at" name="symlink_at"></a> <a href="#symlink_at"><code>symlink-at</code></a></h4>
 <p>Create a symbolic link (also known as a &quot;symlink&quot;).</p>
+<p>If <code>old-path</code> starts with <code>/</code>, the function fails with <a href="#errno.perm"><code>errno::perm</code></a>.</p>
 <p>Note: This is similar to <code>symlinkat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>

--- a/wasi-filesystem.html
+++ b/wasi-filesystem.html
@@ -743,6 +743,8 @@ Bit: 0</p>
 <hr />
 <h4><a href="#read_via_stream" name="read_via_stream"></a> <a href="#read_via_stream"><code>read-via-stream</code></a></h4>
 <p>Return a stream for reading from a file.</p>
+<p>Multiple read, write, and append streams may be active on the same open
+file and they do not interfere with each other.</p>
 <p>Note: This allows using <code>read-stream</code>, which is similar to <a href="#read"><code>read</code></a> in POSIX.</p>
 <h5>Params</h5>
 <ul>
@@ -774,7 +776,6 @@ Bit: 0</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#append_via_stream.this" name="append_via_stream.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a href="#append_via_stream.fd" name="append_via_stream.fd"></a> <code>fd</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
@@ -843,7 +844,7 @@ from <code>fdstat_get</code> in earlier versions of WASI.</p>
 <hr />
 <h4><a href="#set_flags" name="set_flags"></a> <a href="#set_flags"><code>set-flags</code></a></h4>
 <p>Set status flags associated with a descriptor.</p>
-<p>This function may only change the <code>append</code> and <code>nonblock</code> flags.</p>
+<p>This function may only change the <code>nonblock</code> flag.</p>
 <p>Note: This is similar to <code>fcntl(fd, F_SETFL, flags)</code> in POSIX.</p>
 <p>Note: This was called <code>fd_fdstat_set_flags</code> in earlier versions of WASI.</p>
 <h5>Params</h5>
@@ -927,7 +928,8 @@ the write set to zero.</p>
 and their parents, often named <code>.</code> and <code>..</code> respectively, these entries
 are omitted.</p>
 <p>This always returns a new stream which starts at the beginning of the
-directory.</p>
+directory. Multiple streams may be active on the same directory, and they
+do not interfere with each other.</p>
 <h5>Params</h5>
 <ul>
 <li><a href="#readdir.this" name="readdir.this"></a> <code>this</code>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
@@ -1035,8 +1037,8 @@ guaranteed to be less than 2**31.</p>
 <p>If <a href="#flags"><code>flags</code></a> contains <a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a>, and the base
 descriptor doesn't have <a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a> set,
 <a href="#open_at"><code>open-at</code></a> fails with <a href="#errno.rofs"><code>errno::rofs</code></a>.</p>
-<p>If <a href="#flags"><code>flags</code></a> contains <a href="#write"><code>write</code></a> or <code>append</code>, or <a href="#o_flags"><code>o-flags</code></a> contains <code>trunc</code>
-or <code>create</code>, and the base descriptor doesn't have
+<p>If <a href="#flags"><code>flags</code></a> contains <a href="#write"><code>write</code></a> or <code>mutate-directory</code>, or <a href="#o_flags"><code>o-flags</code></a> contains
+<code>trunc</code> or <code>create</code>, and the base descriptor doesn't have
 <a href="#descriptor_flags.mutate_directory"><code>descriptor-flags::mutate-directory</code></a> set, <a href="#open_at"><code>open-at</code></a> fails with
 <a href="#errno.rofs"><code>errno::rofs</code></a>.</p>
 <p>Note: This is similar to <code>openat</code> in POSIX.</p>
@@ -1056,6 +1058,8 @@ or <code>create</code>, and the base descriptor doesn't have
 <hr />
 <h4><a href="#readlink_at" name="readlink_at"></a> <a href="#readlink_at"><code>readlink-at</code></a></h4>
 <p>Read the contents of a symbolic link.</p>
+<p>If the contents contain an absolute or rooted path in the underlying
+filesystem, this function fails with <a href="#errno.perm"><code>errno::perm</code></a>.</p>
 <p>Note: This is similar to <code>readlinkat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
@@ -1097,7 +1101,7 @@ or <code>create</code>, and the base descriptor doesn't have
 </ul>
 <hr />
 <h4><a href="#symlink_at" name="symlink_at"></a> <a href="#symlink_at"><code>symlink-at</code></a></h4>
-<p>Create a symbolic link.</p>
+<p>Create a symbolic link (also known as a &quot;symlink&quot;).</p>
 <p>Note: This is similar to <code>symlinkat</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>

--- a/wasi-filesystem.md
+++ b/wasi-filesystem.md
@@ -1310,6 +1310,8 @@ Note: This is similar to `renameat` in POSIX.
 
 Create a symbolic link (also known as a "symlink").
 
+If `old-path` starts with `/`, the function fails with `errno::perm`.
+
 Note: This is similar to `symlinkat` in POSIX.
 ##### Params
 

--- a/wasi-filesystem.md
+++ b/wasi-filesystem.md
@@ -81,13 +81,6 @@ types.
 This conceptually represents a `stream<u8, _>`. It's temporary
 scaffolding until component-model's async features are ready.
 
-`output-stream`s are *non-blocking* to the extent practical on
-underlying platforms. Except where specified otherwise, I/O operations also
-always return promptly, after the number of bytes that can be written
-promptly, which could even be zero. To wait for the stream to be ready to
-accept data, the `subscribe-to-output-stream` function to obtain a
-`pollable` which can be polled for using `wasi_poll`.
-
 And at present, it is a `u32` instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.
 
@@ -100,13 +93,6 @@ types.
 
 This conceptually represents a `stream<u8, _>`. It's temporary
 scaffolding until component-model's async features are ready.
-
-`input-stream`s are *non-blocking* to the extent practical on underlying
-platforms. I/O operations always return promptly; if fewer bytes are
-promptly available than requested, they return the number of bytes promptly
-available, which could even be zero. To wait for data to be available,
-use the `subscribe-to-input-stream` function to obtain a `pollable` which
-can be polled for using `wasi_poll`.
 
 And at present, it is a `u32` instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.
@@ -232,9 +218,6 @@ Read from one stream and write to another.
 
 This function returns the number of bytes transferred; it may be less
 than `len`.
-
-Unlike other I/O functions, this function blocks until all the data
-read from the input stream has been written to the output stream.
 ##### Params
 
 - <a href="#splice.this" name="splice.this"></a> `this`: [`output-stream`](#output_stream)
@@ -253,10 +236,6 @@ Forward the entire contents of an input stream to an output stream.
 This function repeatedly reads from the input stream and writes
 the data to the output stream, until the end of the input stream
 is reached, or an error is encountered.
-
-Unlike other I/O functions, this function blocks until the end
-of the input stream is seen and all the data has been written to
-the output stream.
 
 This function returns the number of bytes transferred.
 ##### Params

--- a/wasi-filesystem.md
+++ b/wasi-filesystem.md
@@ -81,6 +81,13 @@ types.
 This conceptually represents a `stream<u8, _>`. It's temporary
 scaffolding until component-model's async features are ready.
 
+`output-stream`s are *non-blocking* to the extent practical on
+underlying platforms. Except where specified otherwise, I/O operations also
+always return promptly, after the number of bytes that can be written
+promptly, which could even be zero. To wait for the stream to be ready to
+accept data, the `subscribe-to-output-stream` function to obtain a
+`pollable` which can be polled for using `wasi_poll`.
+
 And at present, it is a `u32` instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.
 
@@ -93,6 +100,13 @@ types.
 
 This conceptually represents a `stream<u8, _>`. It's temporary
 scaffolding until component-model's async features are ready.
+
+`input-stream`s are *non-blocking* to the extent practical on underlying
+platforms. I/O operations always return promptly; if fewer bytes are
+promptly available than requested, they return the number of bytes promptly
+available, which could even be zero. To wait for data to be available,
+use the `subscribe-to-input-stream` function to obtain a `pollable` which
+can be polled for using `wasi_poll`.
 
 And at present, it is a `u32` instead of being an actual handle, until
 the wit-bindgen implementation of handles and resources is ready.
@@ -218,6 +232,9 @@ Read from one stream and write to another.
 
 This function returns the number of bytes transferred; it may be less
 than `len`.
+
+Unlike other I/O functions, this function blocks until all the data
+read from the input stream has been written to the output stream.
 ##### Params
 
 - <a href="#splice.this" name="splice.this"></a> `this`: [`output-stream`](#output_stream)
@@ -236,6 +253,10 @@ Forward the entire contents of an input stream to an output stream.
 This function repeatedly reads from the input stream and writes
 the data to the output stream, until the end of the input stream
 is reached, or an error is encountered.
+
+Unlike other I/O functions, this function blocks until the end
+of the input stream is seen and all the data has been written to
+the output stream.
 
 This function returns the number of bytes transferred.
 ##### Params
@@ -368,7 +389,20 @@ Size: 4, Alignment: 4
 
 Size: 16, Alignment: 8
 
-## <a href="#o_flags" name="o_flags"></a> `o-flags`: record
+## <a href="#path_flags" name="path_flags"></a> `path-flags`: record
+
+Flags determining the method of how paths are resolved.
+
+Size: 1, Alignment: 1
+
+### Record Fields
+
+- <a href="path_flags.symlink_follow" name="path_flags.symlink_follow"></a> [`symlink-follow`](#path_flags.symlink_follow): 
+  
+  As long as the resolved path corresponds to a symbolic link, it is expanded.
+  Bit: 0
+
+## <a href="#open_flags" name="open_flags"></a> `open-flags`: record
 
 Open flags used by `open-at`.
 
@@ -376,27 +410,27 @@ Size: 1, Alignment: 1
 
 ### Record Fields
 
-- <a href="o_flags.create" name="o_flags.create"></a> [`create`](#o_flags.create): 
+- <a href="open_flags.create" name="open_flags.create"></a> [`create`](#open_flags.create): 
   
   Create file if it does not exist.
   Bit: 0
 
-- <a href="o_flags.directory" name="o_flags.directory"></a> [`directory`](#o_flags.directory): 
+- <a href="open_flags.directory" name="open_flags.directory"></a> [`directory`](#open_flags.directory): 
   
   Fail if not a directory.
   Bit: 1
 
-- <a href="o_flags.excl" name="o_flags.excl"></a> [`excl`](#o_flags.excl): 
+- <a href="open_flags.exclusive" name="open_flags.exclusive"></a> [`exclusive`](#open_flags.exclusive): 
   
   Fail if file already exists.
   Bit: 2
 
-- <a href="o_flags.trunc" name="o_flags.trunc"></a> [`trunc`](#o_flags.trunc): 
+- <a href="open_flags.truncate" name="open_flags.truncate"></a> [`truncate`](#open_flags.truncate): 
   
   Truncate file to size 0.
   Bit: 3
 
-## <a href="#mode" name="mode"></a> `mode`: record
+## <a href="#modes" name="modes"></a> `modes`: record
 
 Permissions mode used by `open-at`, `change-file-permissions-at`, and
 similar.
@@ -405,25 +439,25 @@ Size: 1, Alignment: 1
 
 ### Record Fields
 
-- <a href="mode.readable" name="mode.readable"></a> [`readable`](#mode.readable): 
+- <a href="modes.readable" name="modes.readable"></a> [`readable`](#modes.readable): 
   
   True if the resource is considered readable by the containing
   filesystem.
   Bit: 0
 
-- <a href="mode.writeable" name="mode.writeable"></a> [`writeable`](#mode.writeable): 
+- <a href="modes.writeable" name="modes.writeable"></a> [`writeable`](#modes.writeable): 
   
   True if the resource is considered writeable by the containing
   filesystem.
   Bit: 1
 
-- <a href="mode.executable" name="mode.executable"></a> [`executable`](#mode.executable): 
+- <a href="modes.executable" name="modes.executable"></a> [`executable`](#modes.executable): 
   
   True if the resource is considered executable by the containing
   filesystem. This does not apply to directories.
   Bit: 2
 
-## <a href="#linkcount" name="linkcount"></a> `linkcount`: `u64`
+## <a href="#link_count" name="link_count"></a> `link-count`: `u64`
 
 Number of hard links to an inode.
 
@@ -441,7 +475,7 @@ File size or length of a region within a file.
 
 Size: 8, Alignment: 8
 
-## <a href="#errno" name="errno"></a> `errno`: enum
+## <a href="#error_code" name="error_code"></a> `error-code`: enum
 
 Error codes returned by functions.
 Not all of these error codes are returned by the functions provided by this
@@ -452,159 +486,155 @@ Size: 1, Alignment: 1
 
 ### Enum Cases
 
-- <a href="errno.access" name="errno.access"></a> [`access`](#errno.access)
+- <a href="error_code.access" name="error_code.access"></a> [`access`](#error_code.access)
   
   Permission denied.
   
-- <a href="errno.again" name="errno.again"></a> [`again`](#errno.again)
+- <a href="error_code.would_block" name="error_code.would_block"></a> [`would-block`](#error_code.would_block)
   
   Resource unavailable, or operation would block.
   
-- <a href="errno.already" name="errno.already"></a> [`already`](#errno.already)
+- <a href="error_code.already" name="error_code.already"></a> [`already`](#error_code.already)
   
   Connection already in progress.
   
-- <a href="errno.badf" name="errno.badf"></a> [`badf`](#errno.badf)
+- <a href="error_code.bad_descriptor" name="error_code.bad_descriptor"></a> [`bad-descriptor`](#error_code.bad_descriptor)
   
   Bad descriptor.
   
-- <a href="errno.busy" name="errno.busy"></a> [`busy`](#errno.busy)
+- <a href="error_code.busy" name="error_code.busy"></a> [`busy`](#error_code.busy)
   
   Device or resource busy.
   
-- <a href="errno.deadlk" name="errno.deadlk"></a> [`deadlk`](#errno.deadlk)
+- <a href="error_code.deadlock" name="error_code.deadlock"></a> [`deadlock`](#error_code.deadlock)
   
   Resource deadlock would occur.
   
-- <a href="errno.dquot" name="errno.dquot"></a> [`dquot`](#errno.dquot)
+- <a href="error_code.quota" name="error_code.quota"></a> [`quota`](#error_code.quota)
   
   Storage quota exceeded.
   
-- <a href="errno.exist" name="errno.exist"></a> [`exist`](#errno.exist)
+- <a href="error_code.exist" name="error_code.exist"></a> [`exist`](#error_code.exist)
   
   File exists.
   
-- <a href="errno.fbig" name="errno.fbig"></a> [`fbig`](#errno.fbig)
+- <a href="error_code.file_too_large" name="error_code.file_too_large"></a> [`file-too-large`](#error_code.file_too_large)
   
   File too large.
   
-- <a href="errno.ilseq" name="errno.ilseq"></a> [`ilseq`](#errno.ilseq)
+- <a href="error_code.illegal_byte_sequence" name="error_code.illegal_byte_sequence"></a> [`illegal-byte-sequence`](#error_code.illegal_byte_sequence)
   
   Illegal byte sequence.
   
-- <a href="errno.inprogress" name="errno.inprogress"></a> [`inprogress`](#errno.inprogress)
+- <a href="error_code.in_progress" name="error_code.in_progress"></a> [`in-progress`](#error_code.in_progress)
   
   Operation in progress.
   
-- <a href="errno.intr" name="errno.intr"></a> [`intr`](#errno.intr)
+- <a href="error_code.interrupted" name="error_code.interrupted"></a> [`interrupted`](#error_code.interrupted)
   
   Interrupted function.
   
-- <a href="errno.inval" name="errno.inval"></a> [`inval`](#errno.inval)
+- <a href="error_code.invalid" name="error_code.invalid"></a> [`invalid`](#error_code.invalid)
   
   Invalid argument.
   
-- <a href="errno.io" name="errno.io"></a> [`io`](#errno.io)
+- <a href="error_code.io" name="error_code.io"></a> [`io`](#error_code.io)
   
   I/O error.
   
-- <a href="errno.isdir" name="errno.isdir"></a> [`isdir`](#errno.isdir)
+- <a href="error_code.is_directory" name="error_code.is_directory"></a> [`is-directory`](#error_code.is_directory)
   
   Is a directory.
   
-- <a href="errno.loop" name="errno.loop"></a> [`loop`](#errno.loop)
+- <a href="error_code.loop" name="error_code.loop"></a> [`loop`](#error_code.loop)
   
   Too many levels of symbolic links.
   
-- <a href="errno.mlink" name="errno.mlink"></a> [`mlink`](#errno.mlink)
+- <a href="error_code.too_many_links" name="error_code.too_many_links"></a> [`too-many-links`](#error_code.too_many_links)
   
   Too many links.
   
-- <a href="errno.msgsize" name="errno.msgsize"></a> [`msgsize`](#errno.msgsize)
+- <a href="error_code.message_size" name="error_code.message_size"></a> [`message-size`](#error_code.message_size)
   
   Message too large.
   
-- <a href="errno.nametoolong" name="errno.nametoolong"></a> [`nametoolong`](#errno.nametoolong)
+- <a href="error_code.name_too_long" name="error_code.name_too_long"></a> [`name-too-long`](#error_code.name_too_long)
   
   Filename too long.
   
-- <a href="errno.nodev" name="errno.nodev"></a> [`nodev`](#errno.nodev)
+- <a href="error_code.no_device" name="error_code.no_device"></a> [`no-device`](#error_code.no_device)
   
   No such device.
   
-- <a href="errno.noent" name="errno.noent"></a> [`noent`](#errno.noent)
+- <a href="error_code.no_entry" name="error_code.no_entry"></a> [`no-entry`](#error_code.no_entry)
   
   No such file or directory.
   
-- <a href="errno.nolck" name="errno.nolck"></a> [`nolck`](#errno.nolck)
+- <a href="error_code.no_lock" name="error_code.no_lock"></a> [`no-lock`](#error_code.no_lock)
   
   No locks available.
   
-- <a href="errno.nomem" name="errno.nomem"></a> [`nomem`](#errno.nomem)
+- <a href="error_code.insufficient_memory" name="error_code.insufficient_memory"></a> [`insufficient-memory`](#error_code.insufficient_memory)
   
   Not enough space.
   
-- <a href="errno.nospc" name="errno.nospc"></a> [`nospc`](#errno.nospc)
+- <a href="error_code.insufficient_space" name="error_code.insufficient_space"></a> [`insufficient-space`](#error_code.insufficient_space)
   
   No space left on device.
   
-- <a href="errno.nosys" name="errno.nosys"></a> [`nosys`](#errno.nosys)
-  
-  Function not supported.
-  
-- <a href="errno.notdir" name="errno.notdir"></a> [`notdir`](#errno.notdir)
+- <a href="error_code.not_directory" name="error_code.not_directory"></a> [`not-directory`](#error_code.not_directory)
   
   Not a directory or a symbolic link to a directory.
   
-- <a href="errno.notempty" name="errno.notempty"></a> [`notempty`](#errno.notempty)
+- <a href="error_code.not_empty" name="error_code.not_empty"></a> [`not-empty`](#error_code.not_empty)
   
   Directory not empty.
   
-- <a href="errno.notrecoverable" name="errno.notrecoverable"></a> [`notrecoverable`](#errno.notrecoverable)
+- <a href="error_code.not_recoverable" name="error_code.not_recoverable"></a> [`not-recoverable`](#error_code.not_recoverable)
   
   State not recoverable.
   
-- <a href="errno.notsup" name="errno.notsup"></a> [`notsup`](#errno.notsup)
+- <a href="error_code.unsupported" name="error_code.unsupported"></a> [`unsupported`](#error_code.unsupported)
   
-  Not supported, or operation not supported on socket.
+  Not supported
   
-- <a href="errno.notty" name="errno.notty"></a> [`notty`](#errno.notty)
+- <a href="error_code.no_tty" name="error_code.no_tty"></a> [`no-tty`](#error_code.no_tty)
   
   Inappropriate I/O control operation.
   
-- <a href="errno.nxio" name="errno.nxio"></a> [`nxio`](#errno.nxio)
+- <a href="error_code.no_such_device" name="error_code.no_such_device"></a> [`no-such-device`](#error_code.no_such_device)
   
   No such device or address.
   
-- <a href="errno.overflow" name="errno.overflow"></a> [`overflow`](#errno.overflow)
+- <a href="error_code.overflow" name="error_code.overflow"></a> [`overflow`](#error_code.overflow)
   
   Value too large to be stored in data type.
   
-- <a href="errno.perm" name="errno.perm"></a> [`perm`](#errno.perm)
+- <a href="error_code.not_permitted" name="error_code.not_permitted"></a> [`not-permitted`](#error_code.not_permitted)
   
   Operation not permitted.
   
-- <a href="errno.pipe" name="errno.pipe"></a> [`pipe`](#errno.pipe)
+- <a href="error_code.pipe" name="error_code.pipe"></a> [`pipe`](#error_code.pipe)
   
   Broken pipe.
   
-- <a href="errno.rofs" name="errno.rofs"></a> [`rofs`](#errno.rofs)
+- <a href="error_code.read_only" name="error_code.read_only"></a> [`read-only`](#error_code.read_only)
   
   Read-only file system.
   
-- <a href="errno.spipe" name="errno.spipe"></a> [`spipe`](#errno.spipe)
+- <a href="error_code.invalid_seek" name="error_code.invalid_seek"></a> [`invalid-seek`](#error_code.invalid_seek)
   
   Invalid seek.
   
-- <a href="errno.txtbsy" name="errno.txtbsy"></a> [`txtbsy`](#errno.txtbsy)
+- <a href="error_code.text_file_busy" name="error_code.text_file_busy"></a> [`text-file-busy`](#error_code.text_file_busy)
   
   Text file busy.
   
-- <a href="errno.xdev" name="errno.xdev"></a> [`xdev`](#errno.xdev)
+- <a href="error_code.cross_device" name="error_code.cross_device"></a> [`cross-device`](#error_code.cross_device)
   
   Cross-device link.
   
-## <a href="#dir_entry_stream" name="dir_entry_stream"></a> `dir-entry-stream`: `u32`
+## <a href="#directory_entry_stream" name="directory_entry_stream"></a> `directory-entry-stream`: `u32`
 
 A stream of directory entries.
 
@@ -660,7 +690,7 @@ Size: 1, Alignment: 1
   
   The descriptor refers to a socket.
   
-## <a href="#dir_entry" name="dir_entry"></a> `dir-entry`: record
+## <a href="#directory_entry" name="directory_entry"></a> `directory-entry`: record
 
 A directory entry.
 
@@ -668,7 +698,7 @@ Size: 32, Alignment: 8
 
 ### Record Fields
 
-- <a href="dir_entry.ino" name="dir_entry.ino"></a> [`ino`](#dir_entry.ino): option<[`inode`](#inode)>
+- <a href="directory_entry.inode" name="directory_entry.inode"></a> [`inode`](#directory_entry.inode): option<[`inode`](#inode)>
   
   The serial number of the object referred to by this directory entry.
   May be none if the inode value is not known.
@@ -677,11 +707,11 @@ Size: 32, Alignment: 8
   call to retrieve the inode number to fill their `d_ino` fields, so
   implementations which can set this to a non-none value should do so.
   
-- <a href="dir_entry.type" name="dir_entry.type"></a> [`type`](#dir_entry.type): [`descriptor-type`](#descriptor_type)
+- <a href="directory_entry.type" name="directory_entry.type"></a> [`type`](#directory_entry.type): [`descriptor-type`](#descriptor_type)
   
   The type of the file referred to by this directory entry.
   
-- <a href="dir_entry.name" name="dir_entry.name"></a> [`name`](#dir_entry.name): `string`
+- <a href="directory_entry.name" name="directory_entry.name"></a> [`name`](#directory_entry.name): `string`
   
   The name of the object.
   
@@ -705,17 +735,17 @@ Size: 1, Alignment: 1
   Write mode: Data can be written to.
   Bit: 1
 
-- <a href="descriptor_flags.nonblock" name="descriptor_flags.nonblock"></a> [`nonblock`](#descriptor_flags.nonblock): 
+- <a href="descriptor_flags.non_blocking" name="descriptor_flags.non_blocking"></a> [`non-blocking`](#descriptor_flags.non_blocking): 
   
   Requests non-blocking operation.
   
   When this flag is enabled, functions may return immediately with an
-  `errno::again` error code in situations where they would otherwise
+  `error-code::would-block` error code in situations where they would otherwise
   block. However, this non-blocking behavior is not required.
   Implementations are permitted to ignore this flag and block.
   Bit: 2
 
-- <a href="descriptor_flags.sync" name="descriptor_flags.sync"></a> [`sync`](#descriptor_flags.sync): 
+- <a href="descriptor_flags.file_integrity_sync" name="descriptor_flags.file_integrity_sync"></a> [`file-integrity-sync`](#descriptor_flags.file_integrity_sync): 
   
   Request that writes be performed according to synchronized I/O file
   integrity completion. The data stored in the file and the file's
@@ -726,7 +756,7 @@ Size: 1, Alignment: 1
   requirement.
   Bit: 3
 
-- <a href="descriptor_flags.dsync" name="descriptor_flags.dsync"></a> [`dsync`](#descriptor_flags.dsync): 
+- <a href="descriptor_flags.data_integrity_sync" name="descriptor_flags.data_integrity_sync"></a> [`data-integrity-sync`](#descriptor_flags.data_integrity_sync): 
   
   Request that writes be performed according to synchronized I/O data
   integrity completion. Only the data stored in the file is
@@ -737,7 +767,7 @@ Size: 1, Alignment: 1
   requirement.
   Bit: 4
 
-- <a href="descriptor_flags.rsync" name="descriptor_flags.rsync"></a> [`rsync`](#descriptor_flags.rsync): 
+- <a href="descriptor_flags.requested_write_sync" name="descriptor_flags.requested_write_sync"></a> [`requested-write-sync`](#descriptor_flags.requested_write_sync): 
   
   Requests that reads be performed at the same level of integrety
   requested for writes.
@@ -754,7 +784,7 @@ Size: 1, Alignment: 1
   When this flag is unset on a descriptor, operations using the
   descriptor which would create, rename, delete, modify the data or
   metadata of filesystem objects, or obtain another handle which
-  would permit any of those, shall fail with `errno::rofs` if
+  would permit any of those, shall fail with `error-code::read-only` if
   they would otherwise succeed.
   
   This may only be set on directories.
@@ -799,11 +829,11 @@ Size: 88, Alignment: 8
 
 ### Record Fields
 
-- <a href="descriptor_stat.dev" name="descriptor_stat.dev"></a> [`dev`](#descriptor_stat.dev): [`device`](#device)
+- <a href="descriptor_stat.device" name="descriptor_stat.device"></a> [`device`](#descriptor_stat.device): [`device`](#device)
   
   Device ID of device containing the file.
   
-- <a href="descriptor_stat.ino" name="descriptor_stat.ino"></a> [`ino`](#descriptor_stat.ino): [`inode`](#inode)
+- <a href="descriptor_stat.inode" name="descriptor_stat.inode"></a> [`inode`](#descriptor_stat.inode): [`inode`](#inode)
   
   File serial number.
   
@@ -811,7 +841,7 @@ Size: 88, Alignment: 8
   
   File type.
   
-- <a href="descriptor_stat.nlink" name="descriptor_stat.nlink"></a> [`nlink`](#descriptor_stat.nlink): [`linkcount`](#linkcount)
+- <a href="descriptor_stat.link_count" name="descriptor_stat.link_count"></a> [`link-count`](#descriptor_stat.link_count): [`link-count`](#link_count)
   
   Number of hard links to the file.
   
@@ -820,31 +850,18 @@ Size: 88, Alignment: 8
   For regular files, the file size in bytes. For symbolic links, the length
   in bytes of the pathname contained in the symbolic link.
   
-- <a href="descriptor_stat.atim" name="descriptor_stat.atim"></a> [`atim`](#descriptor_stat.atim): [`datetime`](#datetime)
+- <a href="descriptor_stat.data_access_timestamp" name="descriptor_stat.data_access_timestamp"></a> [`data-access-timestamp`](#descriptor_stat.data_access_timestamp): [`datetime`](#datetime)
   
   Last data access timestamp.
   
-- <a href="descriptor_stat.mtim" name="descriptor_stat.mtim"></a> [`mtim`](#descriptor_stat.mtim): [`datetime`](#datetime)
+- <a href="descriptor_stat.data_modification_timestamp" name="descriptor_stat.data_modification_timestamp"></a> [`data-modification-timestamp`](#descriptor_stat.data_modification_timestamp): [`datetime`](#datetime)
   
   Last data modification timestamp.
   
-- <a href="descriptor_stat.ctim" name="descriptor_stat.ctim"></a> [`ctim`](#descriptor_stat.ctim): [`datetime`](#datetime)
+- <a href="descriptor_stat.status_change_timestamp" name="descriptor_stat.status_change_timestamp"></a> [`status-change-timestamp`](#descriptor_stat.status_change_timestamp): [`datetime`](#datetime)
   
   Last file status change timestamp.
   
-## <a href="#at_flags" name="at_flags"></a> `at-flags`: record
-
-Flags determining the method of how paths are resolved.
-
-Size: 1, Alignment: 1
-
-### Record Fields
-
-- <a href="at_flags.symlink_follow" name="at_flags.symlink_follow"></a> [`symlink-follow`](#at_flags.symlink_follow): 
-  
-  As long as the resolved path corresponds to a symbolic link, it is expanded.
-  Bit: 0
-
 ## <a href="#advice" name="advice"></a> `advice`: enum
 
 File or memory access pattern advisory information.
@@ -895,7 +912,7 @@ Note: This allows using `read-stream`, which is similar to `read` in POSIX.
 - <a href="#read_via_stream.offset" name="read_via_stream.offset"></a> `offset`: [`filesize`](#filesize)
 ##### Results
 
-- <a href="#read_via_stream.result0" name="read_via_stream.result0"></a> `result0`: result<[`input-stream`](#input_stream), [`errno`](#errno)>
+- <a href="#read_via_stream.result0" name="read_via_stream.result0"></a> `result0`: result<[`input-stream`](#input_stream), [`error-code`](#error_code)>
 
 ----
 
@@ -910,7 +927,7 @@ Note: This allows using `write-stream`, which is similar to `write` in POSIX.
 - <a href="#write_via_stream.offset" name="write_via_stream.offset"></a> `offset`: [`filesize`](#filesize)
 ##### Results
 
-- <a href="#write_via_stream.result0" name="write_via_stream.result0"></a> `result0`: result<[`output-stream`](#output_stream), [`errno`](#errno)>
+- <a href="#write_via_stream.result0" name="write_via_stream.result0"></a> `result0`: result<[`output-stream`](#output_stream), [`error-code`](#error_code)>
 
 ----
 
@@ -923,30 +940,31 @@ Note: This allows using `write-stream`, which is similar to `write` with
 ##### Params
 
 - <a href="#append_via_stream.this" name="append_via_stream.this"></a> `this`: [`descriptor`](#descriptor)
+- <a href="#append_via_stream.fd" name="append_via_stream.fd"></a> `fd`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#append_via_stream.result0" name="append_via_stream.result0"></a> `result0`: result<[`output-stream`](#output_stream), [`errno`](#errno)>
+- <a href="#append_via_stream.result0" name="append_via_stream.result0"></a> `result0`: result<[`output-stream`](#output_stream), [`error-code`](#error_code)>
 
 ----
 
-#### <a href="#fadvise" name="fadvise"></a> `fadvise` 
+#### <a href="#advise" name="advise"></a> `advise` 
 
 Provide file advisory information on a descriptor.
 
 This is similar to `posix_fadvise` in POSIX.
 ##### Params
 
-- <a href="#fadvise.this" name="fadvise.this"></a> `this`: [`descriptor`](#descriptor)
-- <a href="#fadvise.offset" name="fadvise.offset"></a> `offset`: [`filesize`](#filesize)
-- <a href="#fadvise.len" name="fadvise.len"></a> `len`: [`filesize`](#filesize)
-- <a href="#fadvise.advice" name="fadvise.advice"></a> `advice`: [`advice`](#advice)
+- <a href="#advise.this" name="advise.this"></a> `this`: [`descriptor`](#descriptor)
+- <a href="#advise.offset" name="advise.offset"></a> `offset`: [`filesize`](#filesize)
+- <a href="#advise.length" name="advise.length"></a> `length`: [`filesize`](#filesize)
+- <a href="#advise.advice" name="advise.advice"></a> `advice`: [`advice`](#advice)
 ##### Results
 
-- <a href="#fadvise.result0" name="fadvise.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#advise.result0" name="advise.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
-#### <a href="#datasync" name="datasync"></a> `datasync` 
+#### <a href="#sync_data" name="sync_data"></a> `sync-data` 
 
 Synchronize the data of a file to disk.
 
@@ -956,14 +974,14 @@ opened for writing.
 Note: This is similar to `fdatasync` in POSIX.
 ##### Params
 
-- <a href="#datasync.this" name="datasync.this"></a> `this`: [`descriptor`](#descriptor)
+- <a href="#sync_data.this" name="sync_data.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#datasync.result0" name="datasync.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#sync_data.result0" name="sync_data.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
-#### <a href="#flags" name="flags"></a> `flags` 
+#### <a href="#get_flags" name="get_flags"></a> `get-flags` 
 
 Get flags associated with a descriptor.
 
@@ -973,14 +991,14 @@ Note: This returns the value that was the `fs_flags` value returned
 from `fdstat_get` in earlier versions of WASI.
 ##### Params
 
-- <a href="#flags.this" name="flags.this"></a> `this`: [`descriptor`](#descriptor)
+- <a href="#get_flags.this" name="get_flags.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#flags.result0" name="flags.result0"></a> `result0`: result<[`descriptor-flags`](#descriptor_flags), [`errno`](#errno)>
+- <a href="#get_flags.result0" name="get_flags.result0"></a> `result0`: result<[`descriptor-flags`](#descriptor_flags), [`error-code`](#error_code)>
 
 ----
 
-#### <a href="#type" name="type"></a> `type` 
+#### <a href="#get_type" name="get_type"></a> `get-type` 
 
 Get the dynamic type of a descriptor.
 
@@ -994,10 +1012,10 @@ Note: This returns the value that was the `fs_filetype` value returned
 from `fdstat_get` in earlier versions of WASI.
 ##### Params
 
-- <a href="#type.this" name="type.this"></a> `this`: [`descriptor`](#descriptor)
+- <a href="#get_type.this" name="get_type.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#type.result0" name="type.result0"></a> `result0`: result<[`descriptor-type`](#descriptor_type), [`errno`](#errno)>
+- <a href="#get_type.result0" name="get_type.result0"></a> `result0`: result<[`descriptor-type`](#descriptor_type), [`error-code`](#error_code)>
 
 ----
 
@@ -1005,7 +1023,7 @@ from `fdstat_get` in earlier versions of WASI.
 
 Set status flags associated with a descriptor.
 
-This function may only change the `nonblock` flag.
+This function may only change the `non-blocking` flag.
 
 Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
 
@@ -1016,7 +1034,7 @@ Note: This was called `fd_fdstat_set_flags` in earlier versions of WASI.
 - <a href="#set_flags.flags" name="set_flags.flags"></a> `flags`: [`descriptor-flags`](#descriptor_flags)
 ##### Results
 
-- <a href="#set_flags.result0" name="set_flags.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#set_flags.result0" name="set_flags.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1032,7 +1050,7 @@ Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
 - <a href="#set_size.size" name="set_size.size"></a> `size`: [`filesize`](#filesize)
 ##### Results
 
-- <a href="#set_size.result0" name="set_size.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#set_size.result0" name="set_size.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1046,37 +1064,37 @@ Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
 ##### Params
 
 - <a href="#set_times.this" name="set_times.this"></a> `this`: [`descriptor`](#descriptor)
-- <a href="#set_times.atim" name="set_times.atim"></a> `atim`: [`new-timestamp`](#new_timestamp)
-- <a href="#set_times.mtim" name="set_times.mtim"></a> `mtim`: [`new-timestamp`](#new_timestamp)
+- <a href="#set_times.data_access_timestamp" name="set_times.data_access_timestamp"></a> `data-access-timestamp`: [`new-timestamp`](#new_timestamp)
+- <a href="#set_times.data_modification_timestamp" name="set_times.data_modification_timestamp"></a> `data-modification-timestamp`: [`new-timestamp`](#new_timestamp)
 ##### Results
 
-- <a href="#set_times.result0" name="set_times.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#set_times.result0" name="set_times.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
-#### <a href="#pread" name="pread"></a> `pread` 
+#### <a href="#read" name="read"></a> `read` 
 
 Read from a descriptor, without using and updating the descriptor's offset.
 
 This function returns a list of bytes containing the data that was
 read, along with a bool which, when true, indicates that the end of the
-file was reached. The returned list will contain up to `len` bytes; it
+file was reached. The returned list will contain up to `length` bytes; it
 may return fewer than requested, if the end of the file is reached or
 if the I/O operation is interrupted.
 
 Note: This is similar to `pread` in POSIX.
 ##### Params
 
-- <a href="#pread.this" name="pread.this"></a> `this`: [`descriptor`](#descriptor)
-- <a href="#pread.len" name="pread.len"></a> `len`: [`filesize`](#filesize)
-- <a href="#pread.offset" name="pread.offset"></a> `offset`: [`filesize`](#filesize)
+- <a href="#read.this" name="read.this"></a> `this`: [`descriptor`](#descriptor)
+- <a href="#read.length" name="read.length"></a> `length`: [`filesize`](#filesize)
+- <a href="#read.offset" name="read.offset"></a> `offset`: [`filesize`](#filesize)
 ##### Results
 
-- <a href="#pread.result0" name="pread.result0"></a> `result0`: result<(list<`u8`>, `bool`), [`errno`](#errno)>
+- <a href="#read.result0" name="read.result0"></a> `result0`: result<(list<`u8`>, `bool`), [`error-code`](#error_code)>
 
 ----
 
-#### <a href="#pwrite" name="pwrite"></a> `pwrite` 
+#### <a href="#write" name="write"></a> `write` 
 
 Write to a descriptor, without using and updating the descriptor's offset.
 
@@ -1087,16 +1105,16 @@ the write set to zero.
 Note: This is similar to `pwrite` in POSIX.
 ##### Params
 
-- <a href="#pwrite.this" name="pwrite.this"></a> `this`: [`descriptor`](#descriptor)
-- <a href="#pwrite.buf" name="pwrite.buf"></a> `buf`: list<`u8`>
-- <a href="#pwrite.offset" name="pwrite.offset"></a> `offset`: [`filesize`](#filesize)
+- <a href="#write.this" name="write.this"></a> `this`: [`descriptor`](#descriptor)
+- <a href="#write.buffer" name="write.buffer"></a> `buffer`: list<`u8`>
+- <a href="#write.offset" name="write.offset"></a> `offset`: [`filesize`](#filesize)
 ##### Results
 
-- <a href="#pwrite.result0" name="pwrite.result0"></a> `result0`: result<[`filesize`](#filesize), [`errno`](#errno)>
+- <a href="#write.result0" name="write.result0"></a> `result0`: result<[`filesize`](#filesize), [`error-code`](#error_code)>
 
 ----
 
-#### <a href="#readdir" name="readdir"></a> `readdir` 
+#### <a href="#read_directory" name="read_directory"></a> `read-directory` 
 
 Read directory entries from a directory.
 
@@ -1109,10 +1127,10 @@ directory. Multiple streams may be active on the same directory, and they
 do not interfere with each other.
 ##### Params
 
-- <a href="#readdir.this" name="readdir.this"></a> `this`: [`descriptor`](#descriptor)
+- <a href="#read_directory.this" name="read_directory.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#readdir.result0" name="readdir.result0"></a> `result0`: result<[`dir-entry-stream`](#dir_entry_stream), [`errno`](#errno)>
+- <a href="#read_directory.result0" name="read_directory.result0"></a> `result0`: result<[`directory-entry-stream`](#directory_entry_stream), [`error-code`](#error_code)>
 
 ----
 
@@ -1129,7 +1147,7 @@ Note: This is similar to `fsync` in POSIX.
 - <a href="#sync.this" name="sync.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#sync.result0" name="sync.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#sync.result0" name="sync.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1144,7 +1162,7 @@ Note: This is similar to `mkdirat` in POSIX.
 - <a href="#create_directory_at.path" name="create_directory_at.path"></a> `path`: `string`
 ##### Results
 
-- <a href="#create_directory_at.result0" name="create_directory_at.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#create_directory_at.result0" name="create_directory_at.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1160,7 +1178,7 @@ Note: This was called `fd_filestat_get` in earlier versions of WASI.
 - <a href="#stat.this" name="stat.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#stat.result0" name="stat.result0"></a> `result0`: result<[`descriptor-stat`](#descriptor_stat), [`errno`](#errno)>
+- <a href="#stat.result0" name="stat.result0"></a> `result0`: result<[`descriptor-stat`](#descriptor_stat), [`error-code`](#error_code)>
 
 ----
 
@@ -1174,11 +1192,11 @@ Note: This was called `path_filestat_get` in earlier versions of WASI.
 ##### Params
 
 - <a href="#stat_at.this" name="stat_at.this"></a> `this`: [`descriptor`](#descriptor)
-- <a href="#stat_at.at_flags" name="stat_at.at_flags"></a> `at-flags`: [`at-flags`](#at_flags)
+- <a href="#stat_at.path_flags" name="stat_at.path_flags"></a> `path-flags`: [`path-flags`](#path_flags)
 - <a href="#stat_at.path" name="stat_at.path"></a> `path`: `string`
 ##### Results
 
-- <a href="#stat_at.result0" name="stat_at.result0"></a> `result0`: result<[`descriptor-stat`](#descriptor_stat), [`errno`](#errno)>
+- <a href="#stat_at.result0" name="stat_at.result0"></a> `result0`: result<[`descriptor-stat`](#descriptor_stat), [`error-code`](#error_code)>
 
 ----
 
@@ -1192,13 +1210,13 @@ Note: This was called `path_filestat_set_times` in earlier versions of WASI.
 ##### Params
 
 - <a href="#set_times_at.this" name="set_times_at.this"></a> `this`: [`descriptor`](#descriptor)
-- <a href="#set_times_at.at_flags" name="set_times_at.at_flags"></a> `at-flags`: [`at-flags`](#at_flags)
+- <a href="#set_times_at.path_flags" name="set_times_at.path_flags"></a> `path-flags`: [`path-flags`](#path_flags)
 - <a href="#set_times_at.path" name="set_times_at.path"></a> `path`: `string`
-- <a href="#set_times_at.atim" name="set_times_at.atim"></a> `atim`: [`new-timestamp`](#new_timestamp)
-- <a href="#set_times_at.mtim" name="set_times_at.mtim"></a> `mtim`: [`new-timestamp`](#new_timestamp)
+- <a href="#set_times_at.data_access_timestamp" name="set_times_at.data_access_timestamp"></a> `data-access-timestamp`: [`new-timestamp`](#new_timestamp)
+- <a href="#set_times_at.data_modification_timestamp" name="set_times_at.data_modification_timestamp"></a> `data-modification-timestamp`: [`new-timestamp`](#new_timestamp)
 ##### Results
 
-- <a href="#set_times_at.result0" name="set_times_at.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#set_times_at.result0" name="set_times_at.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1210,13 +1228,13 @@ Note: This is similar to `linkat` in POSIX.
 ##### Params
 
 - <a href="#link_at.this" name="link_at.this"></a> `this`: [`descriptor`](#descriptor)
-- <a href="#link_at.old_at_flags" name="link_at.old_at_flags"></a> `old-at-flags`: [`at-flags`](#at_flags)
+- <a href="#link_at.old_path_flags" name="link_at.old_path_flags"></a> `old-path-flags`: [`path-flags`](#path_flags)
 - <a href="#link_at.old_path" name="link_at.old_path"></a> `old-path`: `string`
 - <a href="#link_at.new_descriptor" name="link_at.new_descriptor"></a> `new-descriptor`: [`descriptor`](#descriptor)
 - <a href="#link_at.new_path" name="link_at.new_path"></a> `new-path`: `string`
 ##### Results
 
-- <a href="#link_at.result0" name="link_at.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#link_at.result0" name="link_at.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1232,25 +1250,25 @@ guaranteed to be less than 2**31.
 
 If `flags` contains `descriptor-flags::mutate-directory`, and the base
 descriptor doesn't have `descriptor-flags::mutate-directory` set,
-`open-at` fails with `errno::rofs`.
+`open-at` fails with `error-code::read-only`.
 
-If `flags` contains `write` or `mutate-directory`, or `o-flags` contains
-`trunc` or `create`, and the base descriptor doesn't have
+If `flags` contains `write` or `mutate-directory`, or `open-flags`
+contains `truncate` or `create`, and the base descriptor doesn't have
 `descriptor-flags::mutate-directory` set, `open-at` fails with
-`errno::rofs`.
+`error-code::read-only`.
 
 Note: This is similar to `openat` in POSIX.
 ##### Params
 
 - <a href="#open_at.this" name="open_at.this"></a> `this`: [`descriptor`](#descriptor)
-- <a href="#open_at.at_flags" name="open_at.at_flags"></a> `at-flags`: [`at-flags`](#at_flags)
+- <a href="#open_at.path_flags" name="open_at.path_flags"></a> `path-flags`: [`path-flags`](#path_flags)
 - <a href="#open_at.path" name="open_at.path"></a> `path`: `string`
-- <a href="#open_at.o_flags" name="open_at.o_flags"></a> `o-flags`: [`o-flags`](#o_flags)
+- <a href="#open_at.open_flags" name="open_at.open_flags"></a> `open-flags`: [`open-flags`](#open_flags)
 - <a href="#open_at.flags" name="open_at.flags"></a> `flags`: [`descriptor-flags`](#descriptor_flags)
-- <a href="#open_at.mode" name="open_at.mode"></a> `mode`: [`mode`](#mode)
+- <a href="#open_at.modes" name="open_at.modes"></a> `modes`: [`modes`](#modes)
 ##### Results
 
-- <a href="#open_at.result0" name="open_at.result0"></a> `result0`: result<[`descriptor`](#descriptor), [`errno`](#errno)>
+- <a href="#open_at.result0" name="open_at.result0"></a> `result0`: result<[`descriptor`](#descriptor), [`error-code`](#error_code)>
 
 ----
 
@@ -1259,7 +1277,7 @@ Note: This is similar to `openat` in POSIX.
 Read the contents of a symbolic link.
 
 If the contents contain an absolute or rooted path in the underlying
-filesystem, this function fails with `errno::perm`.
+filesystem, this function fails with `error-code::not-permitted`.
 
 Note: This is similar to `readlinkat` in POSIX.
 ##### Params
@@ -1268,7 +1286,7 @@ Note: This is similar to `readlinkat` in POSIX.
 - <a href="#readlink_at.path" name="readlink_at.path"></a> `path`: `string`
 ##### Results
 
-- <a href="#readlink_at.result0" name="readlink_at.result0"></a> `result0`: result<`string`, [`errno`](#errno)>
+- <a href="#readlink_at.result0" name="readlink_at.result0"></a> `result0`: result<`string`, [`error-code`](#error_code)>
 
 ----
 
@@ -1276,7 +1294,7 @@ Note: This is similar to `readlinkat` in POSIX.
 
 Remove a directory.
 
-Return `errno::notempty` if the directory is not empty.
+Return `error-code::not-empty` if the directory is not empty.
 
 Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
 ##### Params
@@ -1285,7 +1303,7 @@ Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
 - <a href="#remove_directory_at.path" name="remove_directory_at.path"></a> `path`: `string`
 ##### Results
 
-- <a href="#remove_directory_at.result0" name="remove_directory_at.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#remove_directory_at.result0" name="remove_directory_at.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1302,7 +1320,7 @@ Note: This is similar to `renameat` in POSIX.
 - <a href="#rename_at.new_path" name="rename_at.new_path"></a> `new-path`: `string`
 ##### Results
 
-- <a href="#rename_at.result0" name="rename_at.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#rename_at.result0" name="rename_at.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1310,7 +1328,7 @@ Note: This is similar to `renameat` in POSIX.
 
 Create a symbolic link (also known as a "symlink").
 
-If `old-path` starts with `/`, the function fails with `errno::perm`.
+If `old-path` starts with `/`, the function fails with `error-code::not-permitted`.
 
 Note: This is similar to `symlinkat` in POSIX.
 ##### Params
@@ -1320,7 +1338,7 @@ Note: This is similar to `symlinkat` in POSIX.
 - <a href="#symlink_at.new_path" name="symlink_at.new_path"></a> `new-path`: `string`
 ##### Results
 
-- <a href="#symlink_at.result0" name="symlink_at.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#symlink_at.result0" name="symlink_at.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1328,7 +1346,7 @@ Note: This is similar to `symlinkat` in POSIX.
 
 Unlink a filesystem object that is not a directory.
 
-Return `errno::isdir` if the path refers to a directory.
+Return `error-code::is-directory` if the path refers to a directory.
 Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
 ##### Params
 
@@ -1336,7 +1354,7 @@ Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
 - <a href="#unlink_file_at.path" name="unlink_file_at.path"></a> `path`: `string`
 ##### Results
 
-- <a href="#unlink_file_at.result0" name="unlink_file_at.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#unlink_file_at.result0" name="unlink_file_at.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1351,12 +1369,12 @@ Note: This is similar to `fchmodat` in POSIX.
 ##### Params
 
 - <a href="#change_file_permissions_at.this" name="change_file_permissions_at.this"></a> `this`: [`descriptor`](#descriptor)
-- <a href="#change_file_permissions_at.at_flags" name="change_file_permissions_at.at_flags"></a> `at-flags`: [`at-flags`](#at_flags)
+- <a href="#change_file_permissions_at.path_flags" name="change_file_permissions_at.path_flags"></a> `path-flags`: [`path-flags`](#path_flags)
 - <a href="#change_file_permissions_at.path" name="change_file_permissions_at.path"></a> `path`: `string`
-- <a href="#change_file_permissions_at.mode" name="change_file_permissions_at.mode"></a> `mode`: [`mode`](#mode)
+- <a href="#change_file_permissions_at.modes" name="change_file_permissions_at.modes"></a> `modes`: [`modes`](#modes)
 ##### Results
 
-- <a href="#change_file_permissions_at.result0" name="change_file_permissions_at.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#change_file_permissions_at.result0" name="change_file_permissions_at.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1375,12 +1393,12 @@ Note: This is similar to `fchmodat` in POSIX.
 ##### Params
 
 - <a href="#change_directory_permissions_at.this" name="change_directory_permissions_at.this"></a> `this`: [`descriptor`](#descriptor)
-- <a href="#change_directory_permissions_at.at_flags" name="change_directory_permissions_at.at_flags"></a> `at-flags`: [`at-flags`](#at_flags)
+- <a href="#change_directory_permissions_at.path_flags" name="change_directory_permissions_at.path_flags"></a> `path-flags`: [`path-flags`](#path_flags)
 - <a href="#change_directory_permissions_at.path" name="change_directory_permissions_at.path"></a> `path`: `string`
-- <a href="#change_directory_permissions_at.mode" name="change_directory_permissions_at.mode"></a> `mode`: [`mode`](#mode)
+- <a href="#change_directory_permissions_at.modes" name="change_directory_permissions_at.modes"></a> `modes`: [`modes`](#modes)
 ##### Results
 
-- <a href="#change_directory_permissions_at.result0" name="change_directory_permissions_at.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#change_directory_permissions_at.result0" name="change_directory_permissions_at.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1403,7 +1421,7 @@ non-WASI programs.
 This function blocks until the lock can be acquired.
 
 Not all filesystems support locking; on filesystems which don't support
-locking, this function returns `errno::notsup`.
+locking, this function returns `error-code::unsupported`.
 
 Note: This is similar to `flock(fd, LOCK_SH)` in Unix.
 ##### Params
@@ -1411,7 +1429,7 @@ Note: This is similar to `flock(fd, LOCK_SH)` in Unix.
 - <a href="#lock_shared.this" name="lock_shared.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#lock_shared.result0" name="lock_shared.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#lock_shared.result0" name="lock_shared.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1436,7 +1454,7 @@ with locks acquired by non-WASI programs.
 This function blocks until the lock can be acquired.
 
 Not all filesystems support locking; on filesystems which don't support
-locking, this function returns `errno::notsup`.
+locking, this function returns `error-code::unsupported`.
 
 Note: This is similar to `flock(fd, LOCK_EX)` in Unix.
 ##### Params
@@ -1444,7 +1462,7 @@ Note: This is similar to `flock(fd, LOCK_EX)` in Unix.
 - <a href="#lock_exclusive.this" name="lock_exclusive.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#lock_exclusive.result0" name="lock_exclusive.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#lock_exclusive.result0" name="lock_exclusive.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1464,10 +1482,10 @@ by other programs that don't hold the lock.
 It is unspecified how shared locks interact with locks acquired by
 non-WASI programs.
 
-This function returns `errno::again` if the lock cannot be acquired.
+This function returns `error-code::would-block` if the lock cannot be acquired.
 
 Not all filesystems support locking; on filesystems which don't support
-locking, this function returns `errno::notsup`.
+locking, this function returns `error-code::unsupported`.
 
 Note: This is similar to `flock(fd, LOCK_SH | LOCK_NB)` in Unix.
 ##### Params
@@ -1475,7 +1493,7 @@ Note: This is similar to `flock(fd, LOCK_SH | LOCK_NB)` in Unix.
 - <a href="#try_lock_shared.this" name="try_lock_shared.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#try_lock_shared.result0" name="try_lock_shared.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#try_lock_shared.result0" name="try_lock_shared.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1497,10 +1515,10 @@ It is unspecified whether this function succeeds if the file descriptor
 is not opened for writing. It is unspecified how exclusive locks interact
 with locks acquired by non-WASI programs.
 
-This function returns `errno::again` if the lock cannot be acquired.
+This function returns `error-code::would-block` if the lock cannot be acquired.
 
 Not all filesystems support locking; on filesystems which don't support
-locking, this function returns `errno::notsup`.
+locking, this function returns `error-code::unsupported`.
 
 Note: This is similar to `flock(fd, LOCK_EX | LOCK_NB)` in Unix.
 ##### Params
@@ -1508,7 +1526,7 @@ Note: This is similar to `flock(fd, LOCK_EX | LOCK_NB)` in Unix.
 - <a href="#try_lock_exclusive.this" name="try_lock_exclusive.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#try_lock_exclusive.result0" name="try_lock_exclusive.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#try_lock_exclusive.result0" name="try_lock_exclusive.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1522,7 +1540,7 @@ Note: This is similar to `flock(fd, LOCK_UN)` in Unix.
 - <a href="#unlock.this" name="unlock.this"></a> `this`: [`descriptor`](#descriptor)
 ##### Results
 
-- <a href="#unlock.result0" name="unlock.result0"></a> `result0`: result<_, [`errno`](#errno)>
+- <a href="#unlock.result0" name="unlock.result0"></a> `result0`: result<_, [`error-code`](#error_code)>
 
 ----
 
@@ -1536,23 +1554,23 @@ be used.
 
 ----
 
-#### <a href="#read_dir_entry" name="read_dir_entry"></a> `read-dir-entry` 
+#### <a href="#read_directory_entry" name="read_directory_entry"></a> `read-directory-entry` 
 
-Read a single directory entry from a `dir-entry-stream`.
+Read a single directory entry from a `directory-entry-stream`.
 ##### Params
 
-- <a href="#read_dir_entry.this" name="read_dir_entry.this"></a> `this`: [`dir-entry-stream`](#dir_entry_stream)
+- <a href="#read_directory_entry.this" name="read_directory_entry.this"></a> `this`: [`directory-entry-stream`](#directory_entry_stream)
 ##### Results
 
-- <a href="#read_dir_entry.result0" name="read_dir_entry.result0"></a> `result0`: result<option<[`dir-entry`](#dir_entry)>, [`errno`](#errno)>
+- <a href="#read_directory_entry.result0" name="read_directory_entry.result0"></a> `result0`: result<option<[`directory-entry`](#directory_entry)>, [`error-code`](#error_code)>
 
 ----
 
-#### <a href="#drop_dir_entry_stream" name="drop_dir_entry_stream"></a> `drop-dir-entry-stream` 
+#### <a href="#drop_directory_entry_stream" name="drop_directory_entry_stream"></a> `drop-directory-entry-stream` 
 
-Dispose of the specified `dir-entry-stream`, after which it may no longer
+Dispose of the specified `directory-entry-stream`, after which it may no longer
 be used.
 ##### Params
 
-- <a href="#drop_dir_entry_stream.this" name="drop_dir_entry_stream.this"></a> `this`: [`dir-entry-stream`](#dir_entry_stream)
+- <a href="#drop_directory_entry_stream.this" name="drop_directory_entry_stream.this"></a> `this`: [`directory-entry-stream`](#directory_entry_stream)
 

--- a/wasi-filesystem.md
+++ b/wasi-filesystem.md
@@ -885,6 +885,9 @@ Size: 1, Alignment: 1
 
 Return a stream for reading from a file.
 
+Multiple read, write, and append streams may be active on the same open
+file and they do not interfere with each other.
+
 Note: This allows using `read-stream`, which is similar to `read` in POSIX.
 ##### Params
 
@@ -920,7 +923,6 @@ Note: This allows using `write-stream`, which is similar to `write` with
 ##### Params
 
 - <a href="#append_via_stream.this" name="append_via_stream.this"></a> `this`: [`descriptor`](#descriptor)
-- <a href="#append_via_stream.fd" name="append_via_stream.fd"></a> `fd`: [`descriptor`](#descriptor)
 ##### Results
 
 - <a href="#append_via_stream.result0" name="append_via_stream.result0"></a> `result0`: result<[`output-stream`](#output_stream), [`errno`](#errno)>
@@ -1003,7 +1005,7 @@ from `fdstat_get` in earlier versions of WASI.
 
 Set status flags associated with a descriptor.
 
-This function may only change the `append` and `nonblock` flags.
+This function may only change the `nonblock` flag.
 
 Note: This is similar to `fcntl(fd, F_SETFL, flags)` in POSIX.
 
@@ -1103,7 +1105,8 @@ and their parents, often named `.` and `..` respectively, these entries
 are omitted.
 
 This always returns a new stream which starts at the beginning of the
-directory.
+directory. Multiple streams may be active on the same directory, and they
+do not interfere with each other.
 ##### Params
 
 - <a href="#readdir.this" name="readdir.this"></a> `this`: [`descriptor`](#descriptor)
@@ -1231,8 +1234,8 @@ If `flags` contains `descriptor-flags::mutate-directory`, and the base
 descriptor doesn't have `descriptor-flags::mutate-directory` set,
 `open-at` fails with `errno::rofs`.
 
-If `flags` contains `write` or `append`, or `o-flags` contains `trunc`
-or `create`, and the base descriptor doesn't have
+If `flags` contains `write` or `mutate-directory`, or `o-flags` contains
+`trunc` or `create`, and the base descriptor doesn't have
 `descriptor-flags::mutate-directory` set, `open-at` fails with
 `errno::rofs`.
 
@@ -1254,6 +1257,9 @@ Note: This is similar to `openat` in POSIX.
 #### <a href="#readlink_at" name="readlink_at"></a> `readlink-at` 
 
 Read the contents of a symbolic link.
+
+If the contents contain an absolute or rooted path in the underlying
+filesystem, this function fails with `errno::perm`.
 
 Note: This is similar to `readlinkat` in POSIX.
 ##### Params
@@ -1302,7 +1308,7 @@ Note: This is similar to `renameat` in POSIX.
 
 #### <a href="#symlink_at" name="symlink_at"></a> `symlink-at` 
 
-Create a symbolic link.
+Create a symbolic link (also known as a "symlink").
 
 Note: This is similar to `symlinkat` in POSIX.
 ##### Params

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -20,7 +20,7 @@
 /// function starts with `/`, or if any step of resolving a `path`, including
 /// `..` and symbolic link steps, reaches a directory outside of the base
 /// directory, or reaches a symlink to an absolute or rooted path in the
-/// underlying filesystem, the function fails with `errno::perm`.
+/// underlying filesystem, the function fails with `error-code::not-permitted`.
 default interface wasi-filesystem {
 ```
 
@@ -261,7 +261,7 @@ enum error-code {
     /// File too large.
     file-too-large,
     /// Illegal byte sequence.
-    Illegal-byte-sequence,
+    illegal-byte-sequence,
     /// Operation in progress.
     in-progress,
     /// Interrupted function.
@@ -495,7 +495,7 @@ read: func(
     length: filesize,
     /// The offset within the file at which to read.
     offset: filesize,
-) -> result<tuple<list<u8>, bool>, errno>
+) -> result<tuple<list<u8>, bool>, error-code>
 ```
 
 ## `write`
@@ -658,7 +658,7 @@ open-at: func(
 /// Read the contents of a symbolic link.
 ///
 /// If the contents contain an absolute or rooted path in the underlying
-/// filesystem, this function fails with `errno::perm`.
+/// filesystem, this function fails with `error-code::not-permitted`.
 ///
 /// Note: This is similar to `readlinkat` in POSIX.
 readlink-at: func(
@@ -702,7 +702,7 @@ rename-at: func(
 ```wit
 /// Create a symbolic link (also known as a "symlink").
 ///
-/// If `old-path` starts with `/`, the function fails with `errno::perm`.
+/// If `old-path` starts with `/`, the function fails with `error-code::not-permitted`.
 ///
 /// Note: This is similar to `symlinkat` in POSIX.
 symlink-at: func(

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -12,6 +12,15 @@
 /// Paths are passed as interface-type `string`s, meaning they must consist of
 /// a sequence of Unicode Scalar Values (USVs). Some filesystems may contain paths
 /// which are not accessible by this API.
+///
+/// The directory separator in WASI is always the forward-slash (`/`).
+///
+/// All paths in WASI are relative paths, and are interpreted relative to a
+/// `descriptor` referring to a base directory. If a `path` argument to any WASI
+/// function starts with `/`, or if any step of resolving a `path`, including
+/// `..` and symbolic link steps, reaches a directory outside of the base
+/// directory, or reaches a symlink to an absolute or rooted path in the
+/// underlying filesystem, the function fails with `errno::perm`.
 default interface wasi-filesystem {
 ```
 
@@ -208,7 +217,7 @@ variant new-timestamp {
 
 ## `directory-entry`
 ```wit
-/// A directory entry. 
+/// A directory entry.
 record directory-entry {
     /// The serial number of the object referred to by this directory entry.
     /// May be none if the inode value is not known.
@@ -341,6 +350,9 @@ type descriptor = u32
 ## `read-via-stream`
 ```wit
 /// Return a stream for reading from a file.
+///
+/// Multiple read, write, and append streams may be active on the same open
+/// file and they do not interfere with each other.
 ///
 /// Note: This allows using `read-stream`, which is similar to `read` in POSIX.
 read-via-stream: func(
@@ -514,7 +526,8 @@ write: func(
 /// are omitted.
 ///
 /// This always returns a new stream which starts at the beginning of the
-/// directory.
+/// directory. Multiple streams may be active on the same directory, and they
+/// do not interfere with each other.
 read-directory: func(this: descriptor) -> result<directory-entry-stream, error-code>
 ```
 
@@ -619,8 +632,8 @@ link-at: func(
 /// descriptor doesn't have `descriptor-flags::mutate-directory` set,
 /// `open-at` fails with `error-code::read-only`.
 ///
-/// If `flags` contains `write`, or `open-flags` contains `truncate`
-/// or `create`, and the base descriptor doesn't have
+/// If `flags` contains `write` or `mutate-directory`, or `open-flags`
+/// contains `truncate` or `create`, and the base descriptor doesn't have
 /// `descriptor-flags::mutate-directory` set, `open-at` fails with
 /// `error-code::read-only`.
 ///
@@ -643,6 +656,9 @@ open-at: func(
 ## `readlink-at`
 ```wit
 /// Read the contents of a symbolic link.
+///
+/// If the contents contain an absolute or rooted path in the underlying
+/// filesystem, this function fails with `errno::perm`.
 ///
 /// Note: This is similar to `readlinkat` in POSIX.
 readlink-at: func(
@@ -684,7 +700,7 @@ rename-at: func(
 
 ## `symlink-at`
 ```wit
-/// Create a symbolic link.
+/// Create a symbolic link (also known as a "symlink").
 ///
 /// Note: This is similar to `symlinkat` in POSIX.
 symlink-at: func(

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -118,7 +118,7 @@ flags descriptor-flags {
 ## `descriptor-stat`
 ```wit
 /// File attributes.
-/// 
+///
 /// Note: This was called `filestat` in earlier versions of WASI.
 record descriptor-stat {
     /// Device ID of device containing the file.

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -702,6 +702,8 @@ rename-at: func(
 ```wit
 /// Create a symbolic link (also known as a "symlink").
 ///
+/// If `old-path` starts with `/`, the function fails with `errno::perm`.
+///
 /// Note: This is similar to `symlinkat` in POSIX.
 symlink-at: func(
     this: descriptor,


### PR DESCRIPTION
Fix a spurious extra argument to `append-via-stream`.

Also, add some miscellaneous documentation updates, including:
 - Describing filesystem path separators and sandboxing behavior
 - Clarifying that streams are independent of each other.
 - Remove stale references to the `append` flag.