### PR TITLE
Add an end-of-file return value to `pread`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: curl https://raw.githubusercontent.com/WebAssembly/wasi-poll/75ace039473c05928cfd8e6df0243fc47ee9e8c9/wit/wasi-poll.wit.md > wit/wasi-poll.wit.md
-    - run: curl https://raw.githubusercontent.com/WebAssembly/wasi-io/078a05fdc786b7f4ca7217ac6c0dcfa694c31138/wit/wasi-io.wit.md > wit/wasi-io.wit.md
-    - run: curl https://raw.githubusercontent.com/WebAssembly/wasi-clocks/8e0b562acdd7821be63da61f52f42bf8f4586f5a/wit/wasi-wall-clock.wit.md > wit/wasi-wall-clock.wit.md
+    - run: curl https://raw.githubusercontent.com/WebAssembly/wasi-poll/1bafe7b4a16848a61dd81595ac7f67733561112f/wit/wasi-poll.wit.md > wit/wasi-poll.wit.md
+    - run: curl https://raw.githubusercontent.com/WebAssembly/wasi-io/32ad9a13480d591d1c094dcafdd4d19518e4de93/wit/wasi-io.wit.md > wit/wasi-io.wit.md
+    - run: curl https://raw.githubusercontent.com/WebAssembly/wasi-clocks/778a8323dde9385be37e774558febd7576548984/wit/wasi-wall-clock.wit.md > wit/wasi-wall-clock.wit.md
     - uses: WebAssembly/wit-abi-up-to-date@v10
       with:
         wit-abi-tag: wit-abi-0.8.0

--- a/wasi-filesystem.html
+++ b/wasi-filesystem.html
@@ -25,9 +25,9 @@ that they do not outlive the resource they reference.</p>
 <p>The &quot;oneoff&quot; in the name refers to the fact that this function must do a
 linear scan through the entire list of subscriptions, which may be
 inefficient if the number is large and the same subscriptions are used
-many times. In the future, it may be accompanied by an API similar to
-Linux's <code>epoll</code> which allows sets of subscriptions to be registered and
-made efficiently reusable.</p>
+many times. In the future, this is expected to be obsoleted by the
+component model async proposal, which will include a scalable waiting
+facility.</p>
 <p>Note that the return type would ideally be <code>list&lt;bool&gt;</code>, but that would
 be more difficult to polyfill given the current state of <code>wit-bindgen</code>.
 See <a href="https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061">https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061</a>
@@ -113,16 +113,16 @@ value will be at most <code>len</code>; it may be less.</p>
 <li><a href="#skip.result0" name="skip.result0"></a> <code>result0</code>: result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#subscribe_read" name="subscribe_read"></a> <a href="#subscribe_read"><code>subscribe-read</code></a></h4>
+<h4><a href="#subscribe_to_input_stream" name="subscribe_to_input_stream"></a> <a href="#subscribe_to_input_stream"><code>subscribe-to-input-stream</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream has bytes
 available to read or the other end of the stream has been closed.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#subscribe_read.this" name="subscribe_read.this"></a> <code>this</code>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+<li><a href="#subscribe_to_input_stream.this" name="subscribe_to_input_stream.this"></a> <code>this</code>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#subscribe_read.result0" name="subscribe_read.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+<li><a href="#subscribe_to_input_stream.result0" name="subscribe_to_input_stream.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
 </ul>
 <hr />
 <h4><a href="#drop_input_stream" name="drop_input_stream"></a> <a href="#drop_input_stream"><code>drop-input-stream</code></a></h4>
@@ -192,16 +192,16 @@ is reached, or an error is encountered.</p>
 <li><a href="#forward.result0" name="forward.result0"></a> <code>result0</code>: result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <hr />
-<h4><a href="#subscribe" name="subscribe"></a> <a href="#subscribe"><code>subscribe</code></a></h4>
+<h4><a href="#subscribe_to_output_stream" name="subscribe_to_output_stream"></a> <a href="#subscribe_to_output_stream"><code>subscribe-to-output-stream</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once either the specified stream is ready
 to accept bytes or the other end of the stream has been closed.</p>
 <h5>Params</h5>
 <ul>
-<li><a href="#subscribe.this" name="subscribe.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a href="#subscribe_to_output_stream.this" name="subscribe_to_output_stream.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#subscribe.result0" name="subscribe.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+<li><a href="#subscribe_to_output_stream.result0" name="subscribe_to_output_stream.result0"></a> <code>result0</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
 </ul>
 <hr />
 <h4><a href="#drop_output_stream" name="drop_output_stream"></a> <a href="#drop_output_stream"><code>drop-output-stream</code></a></h4>

--- a/wasi-filesystem.html
+++ b/wasi-filesystem.html
@@ -13,6 +13,13 @@ that they do not outlive the resource they reference.</p>
 <p>Size: 4, Alignment: 4</p>
 <h2>Functions</h2>
 <hr />
+<h4><a href="#drop_pollable" name="drop_pollable"></a> <a href="#drop_pollable"><code>drop-pollable</code></a></h4>
+<p>Dispose of the specified <a href="#pollable"><code>pollable</code></a>, after which it may no longer be used.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#drop_pollable.this" name="drop_pollable.this"></a> <code>this</code>: <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
+</ul>
+<hr />
 <h4><a href="#poll_oneoff" name="poll_oneoff"></a> <a href="#poll_oneoff"><code>poll-oneoff</code></a></h4>
 <p>Poll for completion on a set of pollables.</p>
 <p>The &quot;oneoff&quot; in the name refers to the fact that this function must do a
@@ -23,7 +30,7 @@ Linux's <code>epoll</code> which allows sets of subscriptions to be registered a
 made efficiently reusable.</p>
 <p>Note that the return type would ideally be <code>list&lt;bool&gt;</code>, but that would
 be more difficult to polyfill given the current state of <code>wit-bindgen</code>.
-See https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061
+See <a href="https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061">https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061</a>
 for details.  For now, we use zero to mean &quot;not ready&quot; and non-zero to
 mean &quot;ready&quot;.</p>
 <h5>Params</h5>
@@ -167,6 +174,22 @@ than <code>len</code>.</p>
 <h5>Results</h5>
 <ul>
 <li><a href="#splice.result0" name="splice.result0"></a> <code>result0</code>: result&lt;(<code>u64</code>, <code>bool</code>), <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
+</ul>
+<hr />
+<h4><a href="#forward" name="forward"></a> <a href="#forward"><code>forward</code></a></h4>
+<p>Forward the entire contents of an input stream to an output stream.</p>
+<p>This function repeatedly reads from the input stream and writes
+the data to the output stream, until the end of the input stream
+is reached, or an error is encountered.</p>
+<p>This function returns the number of bytes transferred.</p>
+<h5>Params</h5>
+<ul>
+<li><a href="#forward.this" name="forward.this"></a> <code>this</code>: <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
+<li><a href="#forward.src" name="forward.src"></a> <code>src</code>: <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
+</ul>
+<h5>Results</h5>
+<ul>
+<li><a href="#forward.result0" name="forward.result0"></a> <code>result0</code>: result&lt;<code>u64</code>, <a href="#stream_error"><a href="#stream_error"><code>stream-error</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#subscribe" name="subscribe"></a> <a href="#subscribe"><code>subscribe</code></a></h4>
@@ -864,6 +887,11 @@ extra bytes are filled with zeros.</p>
 <hr />
 <h4><a href="#pread" name="pread"></a> <a href="#pread"><code>pread</code></a></h4>
 <p>Read from a descriptor, without using and updating the descriptor's offset.</p>
+<p>This function returns a list of bytes containing the data that was
+read, along with a bool which, when true, indicates that the end of the
+file was reached. The returned list will contain up to <code>len</code> bytes; it
+may return fewer than requested, if the end of the file is reached or
+if the I/O operation is interrupted.</p>
 <p>Note: This is similar to <a href="#pread"><code>pread</code></a> in POSIX.</p>
 <h5>Params</h5>
 <ul>
@@ -873,7 +901,7 @@ extra bytes are filled with zeros.</p>
 </ul>
 <h5>Results</h5>
 <ul>
-<li><a href="#pread.result0" name="pread.result0"></a> <code>result0</code>: result&lt;list&lt;<code>u8</code>&gt;, <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
+<li><a href="#pread.result0" name="pread.result0"></a> <code>result0</code>: result&lt;(list&lt;<code>u8</code>&gt;, <code>bool</code>), <a href="#errno"><a href="#errno"><code>errno</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h4><a href="#pwrite" name="pwrite"></a> <a href="#pwrite"><code>pwrite</code></a></h4>

--- a/wasi-filesystem.md
+++ b/wasi-filesystem.md
@@ -23,6 +23,15 @@ Size: 4, Alignment: 4
 
 ----
 
+#### <a href="#drop_pollable" name="drop_pollable"></a> `drop-pollable` 
+
+Dispose of the specified `pollable`, after which it may no longer be used.
+##### Params
+
+- <a href="#drop_pollable.this" name="drop_pollable.this"></a> `this`: [`pollable`](#pollable)
+
+----
+
 #### <a href="#poll_oneoff" name="poll_oneoff"></a> `poll-oneoff` 
 
 Poll for completion on a set of pollables.
@@ -36,7 +45,7 @@ made efficiently reusable.
 
 Note that the return type would ideally be `list<bool>`, but that would
 be more difficult to polyfill given the current state of `wit-bindgen`.
-See https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061
+See <https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061>
 for details.  For now, we use zero to mean "not ready" and non-zero to
 mean "ready".
 ##### Params
@@ -217,6 +226,25 @@ than `len`.
 ##### Results
 
 - <a href="#splice.result0" name="splice.result0"></a> `result0`: result<(`u64`, `bool`), [`stream-error`](#stream_error)>
+
+----
+
+#### <a href="#forward" name="forward"></a> `forward` 
+
+Forward the entire contents of an input stream to an output stream.
+
+This function repeatedly reads from the input stream and writes
+the data to the output stream, until the end of the input stream
+is reached, or an error is encountered.
+
+This function returns the number of bytes transferred.
+##### Params
+
+- <a href="#forward.this" name="forward.this"></a> `this`: [`output-stream`](#output_stream)
+- <a href="#forward.src" name="forward.src"></a> `src`: [`input-stream`](#input_stream)
+##### Results
+
+- <a href="#forward.result0" name="forward.result0"></a> `result0`: result<`u64`, [`stream-error`](#stream_error)>
 
 ----
 
@@ -1028,6 +1056,12 @@ Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
 
 Read from a descriptor, without using and updating the descriptor's offset.
 
+This function returns a list of bytes containing the data that was
+read, along with a bool which, when true, indicates that the end of the
+file was reached. The returned list will contain up to `len` bytes; it
+may return fewer than requested, if the end of the file is reached or
+if the I/O operation is interrupted.
+
 Note: This is similar to `pread` in POSIX.
 ##### Params
 
@@ -1036,7 +1070,7 @@ Note: This is similar to `pread` in POSIX.
 - <a href="#pread.offset" name="pread.offset"></a> `offset`: [`filesize`](#filesize)
 ##### Results
 
-- <a href="#pread.result0" name="pread.result0"></a> `result0`: result<list<`u8`>, [`errno`](#errno)>
+- <a href="#pread.result0" name="pread.result0"></a> `result0`: result<(list<`u8`>, `bool`), [`errno`](#errno)>
 
 ----
 

--- a/wasi-filesystem.md
+++ b/wasi-filesystem.md
@@ -39,9 +39,9 @@ Poll for completion on a set of pollables.
 The "oneoff" in the name refers to the fact that this function must do a
 linear scan through the entire list of subscriptions, which may be
 inefficient if the number is large and the same subscriptions are used
-many times. In the future, it may be accompanied by an API similar to
-Linux's `epoll` which allows sets of subscriptions to be registered and
-made efficiently reusable.
+many times. In the future, this is expected to be obsoleted by the
+component model async proposal, which will include a scalable waiting
+facility.
 
 Note that the return type would ideally be `list<bool>`, but that would
 be more difficult to polyfill given the current state of `wit-bindgen`.
@@ -157,16 +157,16 @@ value will be at most `len`; it may be less.
 
 ----
 
-#### <a href="#subscribe_read" name="subscribe_read"></a> `subscribe-read` 
+#### <a href="#subscribe_to_input_stream" name="subscribe_to_input_stream"></a> `subscribe-to-input-stream` 
 
 Create a `pollable` which will resolve once either the specified stream has bytes
 available to read or the other end of the stream has been closed.
 ##### Params
 
-- <a href="#subscribe_read.this" name="subscribe_read.this"></a> `this`: [`input-stream`](#input_stream)
+- <a href="#subscribe_to_input_stream.this" name="subscribe_to_input_stream.this"></a> `this`: [`input-stream`](#input_stream)
 ##### Results
 
-- <a href="#subscribe_read.result0" name="subscribe_read.result0"></a> `result0`: [`pollable`](#pollable)
+- <a href="#subscribe_to_input_stream.result0" name="subscribe_to_input_stream.result0"></a> `result0`: [`pollable`](#pollable)
 
 ----
 
@@ -248,16 +248,16 @@ This function returns the number of bytes transferred.
 
 ----
 
-#### <a href="#subscribe" name="subscribe"></a> `subscribe` 
+#### <a href="#subscribe_to_output_stream" name="subscribe_to_output_stream"></a> `subscribe-to-output-stream` 
 
 Create a `pollable` which will resolve once either the specified stream is ready
 to accept bytes or the other end of the stream has been closed.
 ##### Params
 
-- <a href="#subscribe.this" name="subscribe.this"></a> `this`: [`output-stream`](#output_stream)
+- <a href="#subscribe_to_output_stream.this" name="subscribe_to_output_stream.this"></a> `this`: [`output-stream`](#output_stream)
 ##### Results
 
-- <a href="#subscribe.result0" name="subscribe.result0"></a> `result0`: [`pollable`](#pollable)
+- <a href="#subscribe_to_output_stream.result0" name="subscribe_to_output_stream.result0"></a> `result0`: [`pollable`](#pollable)
 
 ----
 

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -472,9 +472,10 @@ set-times: func(
 /// Read from a descriptor, without using and updating the descriptor's offset.
 ///
 /// This function returns a list of bytes containing the data that was
-/// read, along with a bool indicating whether the end of the file
-/// was reached. The returned list will contain up to `len` bytes; it
-/// may return fewer than requested, but not more.
+/// read, along with a bool which, when true, indicates that the end of the
+/// file was reached. The returned list will contain up to `len` bytes; it
+/// may return fewer than requested, if the end of the file is reached or
+/// if the I/O operation is interrupted.
 ///
 /// Note: This is similar to `pread` in POSIX.
 // TODO(stream<u8, errno>)

--- a/wit/wasi-filesystem.wit.md
+++ b/wit/wasi-filesystem.wit.md
@@ -471,6 +471,11 @@ set-times: func(
 ```wit
 /// Read from a descriptor, without using and updating the descriptor's offset.
 ///
+/// This function returns a list of bytes containing the data that was
+/// read, along with a bool indicating whether the end of the file
+/// was reached. The returned list will contain up to `len` bytes; it
+/// may return fewer than requested, but not more.
+///
 /// Note: This is similar to `pread` in POSIX.
 // TODO(stream<u8, errno>)
 pread: func(
@@ -479,7 +484,7 @@ pread: func(
     len: filesize,
     /// The offset within the file at which to read.
     offset: filesize,
-) -> result<list<u8>, errno>
+) -> result<tuple<list<u8>, bool>, errno>
 ```
 
 ## `pwrite`


### PR DESCRIPTION
Add a way for `pread` to indicate whether it detected the end of the file. This allows users to distinguish the end of the file from a short read for some other reason.