### PR TITLE
Make `read-via-stream` etc. infallible.

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -762,7 +762,7 @@ file and they do not interfere with each other.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="read_via_stream.0"></a> result&lt;<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="read_via_stream.0"></a> <a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a></li>
 </ul>
 <h4><a name="write_via_stream"><code>write-via-stream: func</code></a></h4>
 <p>Return a stream for writing to a file.</p>
@@ -775,7 +775,7 @@ POSIX.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="write_via_stream.0"></a> result&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="write_via_stream.0"></a> <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
 </ul>
 <h4><a name="append_via_stream"><code>append-via-stream: func</code></a></h4>
 <p>Return a stream for appending to a file.</p>
@@ -787,7 +787,7 @@ POSIX.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="append_via_stream.0"></a> result&lt;<a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="append_via_stream.0"></a> <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a></li>
 </ul>
 <h4><a name="advise"><code>advise: func</code></a></h4>
 <p>Provide file advisory information on a descriptor.</p>

--- a/wit/filesystem.wit
+++ b/wit/filesystem.wit
@@ -313,7 +313,7 @@ default interface filesystem {
         this: descriptor,
         /// The offset within the file at which to start reading.
         offset: filesize,
-    ) -> result<input-stream, error-code>
+    ) -> input-stream
 
     /// Return a stream for writing to a file.
     ///
@@ -323,7 +323,7 @@ default interface filesystem {
         this: descriptor,
         /// The offset within the file at which to start writing.
         offset: filesize,
-    ) -> result<output-stream, error-code>
+    ) -> output-stream
 
     /// Return a stream for appending to a file.
     ///
@@ -331,7 +331,7 @@ default interface filesystem {
     /// `O_APPEND` in in POSIX.
     append-via-stream: func(
         this: descriptor,
-    ) -> result<output-stream, error-code>
+    ) -> output-stream
 
     /// Provide file advisory information on a descriptor.
     ///


### PR DESCRIPTION
Make `read-via-stream`, `write-via-stream`, and `append-via-stream` infallible. They don't do any I/O themselves, so they shouldn't fail. And, this is closer to how streams will work in Preview3.