### PR TITLE
Remove the spurious second argument in `append-via-stream`.

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -784,7 +784,6 @@ POSIX.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="append_via_stream.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
-<li><a name="append_via_stream.fd"><code>fd</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>

--- a/wit/filesystem.wit
+++ b/wit/filesystem.wit
@@ -331,8 +331,6 @@ default interface filesystem {
     /// `O_APPEND` in in POSIX.
     append-via-stream: func(
         this: descriptor,
-        /// The resource to operate on.
-        fd: descriptor,
     ) -> result<output-stream, error-code>
 
     /// Provide file advisory information on a descriptor.


### PR DESCRIPTION
Remove the spurious second argument in `append-via-stream`, which is an oversight from the conversion from resources to standalone functions.

I meant to do this in #100 but apparently lost that part of the diff. This PR reinstatates it.