### PR TITLE
Rename filesystem/filesystem to filesystem/types.

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -5,7 +5,7 @@
 <li>interface <a href="#poll"><code>poll</code></a></li>
 <li>interface <a href="#streams"><code>streams</code></a></li>
 <li>interface <a href="#wall_clock"><code>wall-clock</code></a></li>
-<li>interface <a href="#filesystem"><code>filesystem</code></a></li>
+<li>interface <a href="#types"><code>types</code></a></li>
 </ul>
 </li>
 </ul>
@@ -280,7 +280,7 @@ be used.</p>
 <ul>
 <li><a name="drop_wall_clock.this"><code>this</code></a>: <a href="#wall_clock"><a href="#wall_clock"><code>wall-clock</code></a></a></li>
 </ul>
-<h2><a name="filesystem">Import interface filesystem</a></h2>
+<h2><a name="types">Import interface types</a></h2>
 <p>WASI filesystem is a filesystem API primarily intended to let users run WASI
 programs that access their files on their existing filesystems, without
 significant overhead.</p>

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -17,7 +17,7 @@
 /// `..` and symbolic link steps, reaches a directory outside of the base
 /// directory, or reaches a symlink to an absolute or rooted path in the
 /// underlying filesystem, the function fails with `error-code::not-permitted`.
-default interface filesystem {
+default interface types {
     use io.streams.{input-stream, output-stream}
     use clocks.wall-clock.{datetime}
 

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,3 +1,3 @@
 default world example-world {
-    import filesystem: pkg.filesystem
+    import types: pkg.types
 }


### PR DESCRIPTION
Rename filesystem.wit and the `filesystem` interface to types.wit and `types`, respectively. This is inspired by [wasi-http's types.wit], and it means that using filesystem as a dependency looks like "filesystem/types", rather than "filesystem/filesystem", so it looks a little nicer.

[wasi-http's types.wit]: https://github.com/WebAssembly/wasi-http/blob/main/wit/types.wit