### PR TITLE
spelling: correct `writeable` to `writable`

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -416,8 +416,8 @@ similar.</p>
 filesystem.
 </li>
 <li>
-<p><a name="modes.writeable"><code>writeable</code></a>: </p>
-<p>True if the resource is considered writeable by the containing
+<p><a name="modes.writable"><code>writable</code></a>: </p>
+<p>True if the resource is considered writable by the containing
 filesystem.
 </li>
 <li>
@@ -1190,7 +1190,7 @@ filesystem, this function fails with <a href="#error_code.not_permitted"><code>e
 <h4><a name="access_at"><code>access-at: func</code></a></h4>
 <p>Check accessibility of a filesystem path.</p>
 <p>Check whether the given filesystem path names an object which is
-readable, writeable, or executable, or whether it exists.</p>
+readable, writable, or executable, or whether it exists.</p>
 <p>This does not a guarantee that subsequent accesses will succeed, as
 filesystem permissions may be modified asynchronously by external
 entities.</p>

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -146,9 +146,9 @@ default interface types {
         /// True if the resource is considered readable by the containing
         /// filesystem.
         readable,
-        /// True if the resource is considered writeable by the containing
+        /// True if the resource is considered writable by the containing
         /// filesystem.
-        writeable,
+        writable,
         /// True if the resource is considered executable by the containing
         /// filesystem. This does not apply to directories.
         executable,
@@ -615,7 +615,7 @@ default interface types {
     /// Check accessibility of a filesystem path.
     ///
     /// Check whether the given filesystem path names an object which is
-    /// readable, writeable, or executable, or whether it exists.
+    /// readable, writable, or executable, or whether it exists.
     ///
     /// This does not a guarantee that subsequent accesses will succeed, as
     /// filesystem permissions may be modified asynchronously by external


### PR DESCRIPTION
in both the modes flag, and documentation.