### PR TITLE
is-same-object, metadata-hash and metadata-hash-at: add missing this: descriptor argument

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -1415,6 +1415,10 @@ usually change.</li>
 computed hash.</li>
 </ul>
 <p>However, none of these is required.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="metadata_hash.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
+</ul>
 <h5>Return values</h5>
 <ul>
 <li><a name="metadata_hash.0"></a> result&lt;<a href="#metadata_hash_value"><a href="#metadata_hash_value"><code>metadata-hash-value</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
@@ -1425,6 +1429,7 @@ to by a directory descriptor and a relative path.</p>
 <p>This performs the same hash computation as <a href="#metadata_hash"><code>metadata-hash</code></a>.</p>
 <h5>Params</h5>
 <ul>
+<li><a name="metadata_hash_at.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 <li><a name="metadata_hash_at.path_flags"><a href="#path_flags"><code>path-flags</code></a></a>: <a href="#path_flags"><a href="#path_flags"><code>path-flags</code></a></a></li>
 <li><a name="metadata_hash_at.path"><code>path</code></a>: <code>string</code></li>
 </ul>

--- a/example-world.md
+++ b/example-world.md
@@ -1391,6 +1391,7 @@ wasi-filesystem does not expose device and inode numbers, so this function
 may be used instead.</p>
 <h5>Params</h5>
 <ul>
+<li><a name="is_same_object.this"><code>this</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 <li><a name="is_same_object.other"><code>other</code></a>: <a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a></li>
 </ul>
 <h5>Return values</h5>

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -802,7 +802,7 @@ interface types {
     /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
     /// wasi-filesystem does not expose device and inode numbers, so this function
     /// may be used instead.
-    is-same-object: func(other: descriptor) -> bool
+    is-same-object: func(this: descriptor, other: descriptor) -> bool
 
     /// Return a hash of the metadata associated with a filesystem object referred
     /// to by a descriptor.

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -823,13 +823,16 @@ interface types {
     ///    computed hash.
     ///
     /// However, none of these is required.
-    metadata-hash: func() -> result<metadata-hash-value, error-code>
+    metadata-hash: func(
+        this: descriptor,
+    ) -> result<metadata-hash-value, error-code>
 
     /// Return a hash of the metadata associated with a filesystem object referred
     /// to by a directory descriptor and a relative path.
     ///
     /// This performs the same hash computation as `metadata-hash`.
     metadata-hash-at: func(
+        this: descriptor,
         /// Flags determining the method of how the path is resolved.
         path-flags: path-flags,
         /// The relative path of the file or directory to inspect.


### PR DESCRIPTION
These are methods on file/directory descriptors. Add those missing arguments.