### PR TITLE
docs: fix language for portability criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WASI-filesystem is currently in [Phase 2].
 
 - Dan Gohman
 
-### Phase 4 Advancement Criteria
+### Portability Criteria
 
 WASI filesystem must have host implementations which can pass the testsuite
 on at least Windows, macOS, and Linux.


### PR DESCRIPTION
This is to align language in the WASI phase process with all pre-existing WASI repos.

Phase 4 Advancement Criteria was renamed to Portability Criteria in WebAssembly/WASI#549, so rename it in this document.