### PR TITLE
Typos in comments

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -937,7 +937,7 @@ POSIX.</p>
 <p>Return a stream for appending to a file, if available.</p>
 <p>May fail with an error-code describing why the file cannot be appended.</p>
 <p>Note: This allows using <code>write-stream</code>, which is similar to <code>write</code> with
-<code>O_APPEND</code> in in POSIX.</p>
+<code>O_APPEND</code> in POSIX.</p>
 <h5>Params</h5>
 <ul>
 <li><a id="method_descriptor_append_via_stream.self"></a><code>self</code>: borrow&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;</li>
@@ -1284,7 +1284,7 @@ may also include the inode number, device number, birth timestamp, and
 other metadata fields that may change when the file is modified or
 replaced. It may also include a secret value chosen by the
 implementation and not otherwise exposed.</p>
-<p>Implementations are encourated to provide the following properties:</p>
+<p>Implementations are encouraged to provide the following properties:</p>
 <ul>
 <li>If the file is not modified or replaced, the computed hash value should
 usually not change.</li>
@@ -1352,7 +1352,7 @@ errors are filesystem-related errors.</p>
 ----
 <h3>Functions</h3>
 <h4><a id="get_directories"></a><code>get-directories: func</code></h4>
-<p>Return the set of preopened directories, and their path.</p>
+<p>Return the set of preopened directories, and their paths.</p>
 <h5>Return values</h5>
 <ul>
 <li><a id="get_directories.0"></a> list&lt;(own&lt;<a href="#descriptor"><a href="#descriptor"><code>descriptor</code></a></a>&gt;, <code>string</code>)&gt;</li>

--- a/wit/preopens.wit
+++ b/wit/preopens.wit
@@ -5,7 +5,7 @@ interface preopens {
     @since(version = 0.2.0)
     use types.{descriptor};
 
-    /// Return the set of preopened directories, and their path.
+    /// Return the set of preopened directories, and their paths.
     @since(version = 0.2.0)
     get-directories: func() -> list<tuple<descriptor, string>>;
 }

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -327,7 +327,7 @@ interface types {
         /// May fail with an error-code describing why the file cannot be appended.
         ///
         /// Note: This allows using `write-stream`, which is similar to `write` with
-        /// `O_APPEND` in in POSIX.
+        /// `O_APPEND` in POSIX.
         @since(version = 0.2.0)
         append-via-stream: func() -> result<output-stream, error-code>;
 
@@ -623,7 +623,7 @@ interface types {
         /// replaced. It may also include a secret value chosen by the
         /// implementation and not otherwise exposed.
         ///
-        /// Implementations are encourated to provide the following properties:
+        /// Implementations are encouraged to provide the following properties:
         ///
         ///  - If the file is not modified or replaced, the computed hash value should
         ///    usually not change.


### PR DESCRIPTION
and in the imports.md as those comments are duplicated there.