### PR TITLE
Preview3

### DIFF
--- a/wit/types.wit
+++ b/wit/types.wit
@@ -186,8 +186,6 @@ interface types {
         access,
         /// Resource unavailable, or operation would block, similar to `EAGAIN` and `EWOULDBLOCK` in POSIX.
         would-block,
-        /// Connection already in progress, similar to `EALREADY` in POSIX.
-        already,
         /// Device or resource busy, similar to `EBUSY` in POSIX.
         busy,
         /// Resource deadlock would occur, similar to `EDEADLK` in POSIX.
@@ -200,8 +198,6 @@ interface types {
         file-too-large,
         /// Illegal byte sequence, similar to `EILSEQ` in POSIX.
         illegal-byte-sequence,
-        /// Operation in progress, similar to `EINPROGRESS` in POSIX.
-        in-progress,
         /// Interrupted function, similar to `EINTR` in POSIX.
         interrupted,
         /// Invalid argument, similar to `EINVAL` in POSIX.
@@ -214,8 +210,6 @@ interface types {
         loop,
         /// Too many links, similar to `EMLINK` in POSIX.
         too-many-links,
-        /// Message too large, similar to `EMSGSIZE` in POSIX.
-        message-size,
         /// Filename too long, similar to `ENAMETOOLONG` in POSIX.
         name-too-long,
         /// No such device, similar to `ENODEV` in POSIX.

--- a/wit/types.wit
+++ b/wit/types.wit
@@ -188,8 +188,6 @@ interface types {
         would-block,
         /// Connection already in progress, similar to `EALREADY` in POSIX.
         already,
-        /// Bad descriptor, similar to `EBADF` in POSIX.
-        bad-descriptor,
         /// Device or resource busy, similar to `EBUSY` in POSIX.
         busy,
         /// Resource deadlock would occur, similar to `EDEADLK` in POSIX.


### PR DESCRIPTION
This branch keeps track of the backwards-incompatible changes we'd like to make for preview 3. So far, the changes are:

- Remove `bad-descriptor` error code. This is a relic of Preview 1 and the prototype period of Preview 2 before resource types were implemented. In a correct Component Model implementation, this is not possible to reach.
- Remove `already`, `in-progress` & `message-size` error codes, as those relate to sockets and not filesystems.