### PR TITLE
Port #165 to wit-0.3.0.

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -482,6 +482,10 @@ interface types {
 
         /// Create a hard link.
         ///
+        /// Fails with `error-code::no-entry` if the old path does not exist,
+        /// with `error-code::exist` if the new path already exists, and
+        /// `error-code::not-permitted` if the old path is not a file.
+        ///
         /// Note: This is similar to `linkat` in POSIX.
         @since(version = 0.3.0)
         link-at: func(


### PR DESCRIPTION
Port the documentation of the `link` function's error conditions added in #165 to the wit-0.3.0-draft branch.